### PR TITLE
Use maven environment for java publishing

### DIFF
--- a/.github/workflows/java-flyway-release.yml
+++ b/.github/workflows/java-flyway-release.yml
@@ -10,6 +10,7 @@ jobs:
   deploy:
     if: startsWith(github.event.release.tag_name, 'java/flyway/')
     runs-on: ubuntu-latest
+    environment: maven
     steps:
       - uses: actions/checkout@v6
 


### PR DESCRIPTION
This PR adds the `maven` environment to the Flyway publishing workflow. The publishing secrets are now stored there rather than repo-wide.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
