### PR TITLE
Update repo links pointing to old repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,10 +6,10 @@ This monorepo contains ORM and database tool adapters for [Amazon Aurora DSQL](h
 
 ### Python
 
-| Package | Description | PyPI | Version |
-|---------|-------------|------|---------|
-| [aurora-dsql-sqlalchemy](./python/sqlalchemy/) | SQLAlchemy dialect for Aurora DSQL | [PyPI](https://pypi.org/project/aurora-dsql-sqlalchemy/) | 1.1.0 |
-| [aurora-dsql-tortoise-orm](./python/tortoise-orm/) | Tortoise ORM adapter for Aurora DSQL | [PyPI](https://pypi.org/project/aurora-dsql-tortoise-orm/) | 0.1.1 |
+| Package | Description | PyPI |
+|---------|-------------|------|
+| [aurora-dsql-sqlalchemy](./python/sqlalchemy/) | SQLAlchemy dialect for Aurora DSQL | [![PyPI](https://img.shields.io/pypi/v/aurora-dsql-sqlalchemy)](https://pypi.org/project/aurora-dsql-sqlalchemy/) |
+| [aurora-dsql-tortoise-orm](./python/tortoise-orm/) | Tortoise ORM adapter for Aurora DSQL | [![PyPI](https://img.shields.io/pypi/v/aurora-dsql-tortoise-orm)](https://pypi.org/project/aurora-dsql-tortoise-orm/) |
 
 ### TypeScript
 
@@ -17,9 +17,9 @@ This monorepo contains ORM and database tool adapters for [Amazon Aurora DSQL](h
 
 ### Java
 
-| Package | Description | Maven Central | Version |
-|---------|-------------|---------------|---------|
-| [aurora-dsql-flyway-support](./java/flyway/) | Flyway database plugin for Aurora DSQL | *Coming soon* | 1.0.0 |
+| Package | Description | Maven Central |
+|---------|-------------|---------------|
+| [aurora-dsql-flyway-support](./java/flyway/) | Flyway database plugin for Aurora DSQL | [![Maven Central](https://img.shields.io/maven-central/v/software.amazon.dsql/aurora-dsql-flyway-support)](https://central.sonatype.com/artifact/software.amazon.dsql/aurora-dsql-flyway-support) |
 
 ## Installation
 

--- a/python/sqlalchemy/README.md
+++ b/python/sqlalchemy/README.md
@@ -1,7 +1,7 @@
 # Amazon Aurora DSQL dialect for SQLAlchemy
 
-[![GitHub](https://img.shields.io/badge/github-awslabs/aurora--dsql--sqlalchemy-blue?logo=github)](https://github.com/awslabs/aurora-dsql-sqlalchemy)
-[![License](https://img.shields.io/badge/license-Apache--2.0-brightgreen)](https://github.com/awslabs/aurora-dsql-sqlalchemy/blob/main/LICENSE)
+[![GitHub](https://img.shields.io/badge/github-awslabs/aurora--dsql--orms-blue?logo=github)](https://github.com/awslabs/aurora-dsql-orms)
+[![License](https://img.shields.io/badge/license-Apache--2.0-brightgreen)](https://github.com/awslabs/aurora-dsql-orms/blob/main/LICENSE)
 [![PyPI - Version](https://img.shields.io/pypi/v/aurora-dsql-sqlalchemy)](https://pypi.org/project/aurora-dsql-sqlalchemy)
 [![Discord chat](https://img.shields.io/discord/1435027294837276802.svg?logo=discord)](https://discord.com/invite/nEF6ksFWru)
 
@@ -13,8 +13,8 @@ Aurora DSQL's distributed architecture and high availability.
 
 ## Sample Application
 
-There is an included sample application in [examples/pet-clinic-app](https://github.com/awslabs/aurora-dsql-sqlalchemy/tree/main/examples/pet-clinic-app) that shows how to use Aurora DSQL
-with SQLAlchemy. To run the included example please refer to the [sample README](https://github.com/awslabs/aurora-dsql-sqlalchemy/tree/main/examples/pet-clinic-app#readme).
+There is an included sample application in [examples/pet-clinic-app](https://github.com/awslabs/aurora-dsql-orms/tree/main/python/sqlalchemy/examples/pet-clinic-app) that shows how to use Aurora DSQL
+with SQLAlchemy. To run the included example please refer to the [sample README](https://github.com/awslabs/aurora-dsql-orms/tree/main/python/sqlalchemy/examples/pet-clinic-app#readme).
 
 ## Prerequisites
 
@@ -146,11 +146,11 @@ Column(
 
 ## Developer instructions
 
-Instructions on how to build and test the dialect are available in the [Developer Instructions](https://github.com/awslabs/aurora-dsql-sqlalchemy/tree/main/aurora_dsql_sqlalchemy#readme).
+Instructions on how to build and test the dialect are available in the [Developer Instructions](https://github.com/awslabs/aurora-dsql-orms/tree/main/python/sqlalchemy/aurora_dsql_sqlalchemy#readme).
 
 ## Security
 
-See [CONTRIBUTING](https://github.com/awslabs/aurora-dsql-sqlalchemy/blob/main/CONTRIBUTING.md#security-issue-notifications) for more information.
+See [CONTRIBUTING](https://github.com/awslabs/aurora-dsql-orms/blob/main/CONTRIBUTING.md#security-issue-notifications) for more information.
 
 ## License
 

--- a/python/sqlalchemy/aurora_dsql_sqlalchemy/README.md
+++ b/python/sqlalchemy/aurora_dsql_sqlalchemy/README.md
@@ -3,8 +3,8 @@
 ## Clone the repository
 
 ```bash
-git clone https://github.com/awslabs/aurora-dsql-sqlalchemy.git
-cd aurora-dsql-sqlalchemy
+git clone https://github.com/awslabs/aurora-dsql-orms.git
+cd aurora-dsql-orms/python/sqlalchemy
 ```
 
 ## Install `uv`

--- a/python/sqlalchemy/examples/pet-clinic-app/README.md
+++ b/python/sqlalchemy/examples/pet-clinic-app/README.md
@@ -66,9 +66,9 @@ connections should be used where possible to ensure data security during transmi
 
    ```
    # Clone the entire repository
-   git clone https://github.com/awslabs/aurora-dsql-sqlalchemy.git
+   git clone https://github.com/awslabs/aurora-dsql-orms.git
    # Change to the specific directory
-   cd aurora-dsql-sqlalchemy/examples/pet-clinic-app
+   cd aurora-dsql-orms/python/sqlalchemy/examples/pet-clinic-app
    ```
 
 2. Configure SSL certificates

--- a/python/tortoise-orm/README.md
+++ b/python/tortoise-orm/README.md
@@ -1,6 +1,6 @@
 # Aurora DSQL Adapter for Tortoise ORM
 
-[![GitHub](https://img.shields.io/badge/github-awslabs/aurora--dsql--tortoise--orm-blue?logo=github)](https://github.com/awslabs/aurora-dsql-tortoise-orm)
+[![GitHub](https://img.shields.io/badge/github-awslabs/aurora--dsql--orms-blue?logo=github)](https://github.com/awslabs/aurora-dsql-orms)
 [![License](https://img.shields.io/badge/license-Apache--2.0-brightgreen)](LICENSE)
 [![PyPI - Version](https://img.shields.io/pypi/v/aurora-dsql-tortoise-orm)](https://pypi.org/project/aurora-dsql-tortoise-orm)
 [![Discord chat](https://img.shields.io/discord/1435027294837276802.svg?logo=discord)](https://discord.com/invite/nEF6ksFWru)
@@ -124,8 +124,8 @@ The compatibility module patches Aerich to:
 Install [uv](https://docs.astral.sh/uv/getting-started/installation/), then:
 
 ```bash
-git clone https://github.com/awslabs/aurora-dsql-tortoise-orm
-cd aurora-dsql-tortoise-orm
+git clone https://github.com/awslabs/aurora-dsql-orms
+cd aurora-dsql-orms/python/tortoise-orm
 uv sync
 ```
 
@@ -150,7 +150,7 @@ uv run integration
 ## Getting Help
 
 - Open a support ticket with [AWS Support](http://docs.aws.amazon.com/awssupport/latest/user/getting-started.html)
-- Report bugs via [GitHub Issues](https://github.com/awslabs/aurora-dsql-tortoise-orm/issues/new)
+- Report bugs via [GitHub Issues](https://github.com/awslabs/aurora-dsql-orms/issues/new)
 
 ## Additional Resources
 
@@ -160,7 +160,7 @@ uv run integration
 
 ## Opening Issues
 
-If you encounter a bug, please search [existing issues](https://github.com/awslabs/aurora-dsql-tortoise-orm/issues) before opening a new one. GitHub issues are intended for bug reports and feature requests.
+If you encounter a bug, please search [existing issues](https://github.com/awslabs/aurora-dsql-orms/issues) before opening a new one. GitHub issues are intended for bug reports and feature requests.
 
 ## License
 


### PR DESCRIPTION
This PR updates all docs to point to the new monorepo.

## Changes

- Updated GitHub badges in package `README.md` files to point to new repo
- Added live version badges (PyPI/Maven Central) to root `README.md` tables
- Fixed clone instructions to use new repo paths
- Updated sample app, contributing, and issue tracker links


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
