### PR TITLE
Remove unused dsql.region system property from Flyway build

### DIFF
--- a/java/flyway/build.gradle
+++ b/java/flyway/build.gradle
@@ -66,7 +66,6 @@ tasks.register('integrationTest', Test) {
     include '**/*IntegrationTest.class'
 
     systemProperty 'dsql.cluster.endpoint', System.getenv('DSQL_CLUSTER_ENDPOINT') ?: ''
-    systemProperty 'dsql.region', System.getenv('AWS_REGION') ?: ''
 }
 
 publishing {


### PR DESCRIPTION
Removes the unused `dsql.region` system property from the Flyway adapter's Gradle build configuration.

The property was being set from `AWS_REGION` but never read anywhere in the codebase. Only `dsql.cluster.endpoint` is actually used by the integration tests.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
