### PR TITLE
Add missing gitleaks-scan workflow

### DIFF
--- a/.github/workflows/gitleaks-scan.yml
+++ b/.github/workflows/gitleaks-scan.yml
@@ -1,0 +1,25 @@
+name: Gitleaks scan
+
+permissions: {}
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: gitleaks
+        uses: gitleaks/gitleaks-action@v1.6.0
+        env:
+          # GitHub Token automatically created on run
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This PR ports the `gitleaks-scan.yml` action from the original repos to perform secret scanning.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
