### PR TITLE
Add Django copyright headers

### DIFF
--- a/python/django/aurora_dsql_django/__init__.py
+++ b/python/django/aurora_dsql_django/__init__.py
@@ -1,16 +1,5 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
-#
-# Licensed under the Apache License, Version 2.0 (the "License").
-# You may not use this file except in compliance with
-# the License. A copy of the License is located at
-#
-# http://www.apache.org/licenses/LICENSE-2.0
-#
-# or in the "license" file accompanying this file.
-# This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
-# CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions
-# and limitations under the License.
+# SPDX-License-Identifier: Apache-2.0
 
 from importlib.metadata import PackageNotFoundError, version
 

--- a/python/django/aurora_dsql_django/base.py
+++ b/python/django/aurora_dsql_django/base.py
@@ -1,16 +1,5 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
-#
-# Licensed under the Apache License, Version 2.0 (the "License").
-# You may not use this file except in compliance with
-# the License. A copy of the License is located at
-#
-# http://www.apache.org/licenses/LICENSE-2.0
-#
-# or in the "license" file accompanying this file.
-# This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
-# CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions
-# and limitations under the License.
+# SPDX-License-Identifier: Apache-2.0
 
 """
 Aurora DSQL adapter for Django.

--- a/python/django/aurora_dsql_django/creation.py
+++ b/python/django/aurora_dsql_django/creation.py
@@ -1,16 +1,5 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
-#
-# Licensed under the Apache License, Version 2.0 (the "License").
-# You may not use this file except in compliance with
-# the License. A copy of the License is located at
-#
-# http://www.apache.org/licenses/LICENSE-2.0
-#
-# or in the "license" file accompanying this file.
-# This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
-# CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions
-# and limitations under the License.
+# SPDX-License-Identifier: Apache-2.0
 
 """
 This module customizes the default Django database creation for Aurora DSQL.

--- a/python/django/aurora_dsql_django/features.py
+++ b/python/django/aurora_dsql_django/features.py
@@ -1,16 +1,5 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
-#
-# Licensed under the Apache License, Version 2.0 (the "License").
-# You may not use this file except in compliance with
-# the License. A copy of the License is located at
-#
-# http://www.apache.org/licenses/LICENSE-2.0
-#
-# or in the "license" file accompanying this file.
-# This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
-# CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions
-# and limitations under the License.
+# SPDX-License-Identifier: Apache-2.0
 
 """
 A module with custom wrapper that overrides base postgres database features

--- a/python/django/aurora_dsql_django/operations.py
+++ b/python/django/aurora_dsql_django/operations.py
@@ -1,16 +1,5 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
-#
-# Licensed under the Apache License, Version 2.0 (the "License").
-# You may not use this file except in compliance with
-# the License. A copy of the License is located at
-#
-# http://www.apache.org/licenses/LICENSE-2.0
-#
-# or in the "license" file accompanying this file.
-# This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
-# CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions
-# and limitations under the License.
+# SPDX-License-Identifier: Apache-2.0
 
 """
 A module with custom wrapper that overrides base postgres database operations

--- a/python/django/aurora_dsql_django/schema.py
+++ b/python/django/aurora_dsql_django/schema.py
@@ -1,16 +1,5 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
-#
-# Licensed under the Apache License, Version 2.0 (the "License").
-# You may not use this file except in compliance with
-# the License. A copy of the License is located at
-#
-# http://www.apache.org/licenses/LICENSE-2.0
-#
-# or in the "license" file accompanying this file.
-# This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
-# CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions
-# and limitations under the License.
+# SPDX-License-Identifier: Apache-2.0
 
 """
 This module customizes the default Django database schema editor functions

--- a/python/django/aurora_dsql_django/tests/__init__.py
+++ b/python/django/aurora_dsql_django/tests/__init__.py
@@ -1,0 +1,3 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+

--- a/python/django/aurora_dsql_django/tests/integration/__init__.py
+++ b/python/django/aurora_dsql_django/tests/integration/__init__.py
@@ -1,0 +1,3 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+

--- a/python/django/aurora_dsql_django/tests/integration/test_dsql.py
+++ b/python/django/aurora_dsql_django/tests/integration/test_dsql.py
@@ -1,3 +1,6 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
 import os
 
 from django.db import connections, transaction

--- a/python/django/aurora_dsql_django/tests/test_settings.py
+++ b/python/django/aurora_dsql_django/tests/test_settings.py
@@ -1,3 +1,6 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
 import os
 import sys
 

--- a/python/django/aurora_dsql_django/tests/unit/__init__.py
+++ b/python/django/aurora_dsql_django/tests/unit/__init__.py
@@ -1,0 +1,3 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+

--- a/python/django/aurora_dsql_django/tests/unit/test_base.py
+++ b/python/django/aurora_dsql_django/tests/unit/test_base.py
@@ -1,3 +1,6 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
 import unittest
 import uuid
 from unittest.mock import MagicMock, patch

--- a/python/django/aurora_dsql_django/tests/unit/test_creation.py
+++ b/python/django/aurora_dsql_django/tests/unit/test_creation.py
@@ -1,3 +1,6 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
 import unittest
 from unittest.mock import MagicMock, patch
 

--- a/python/django/aurora_dsql_django/tests/unit/test_features.py
+++ b/python/django/aurora_dsql_django/tests/unit/test_features.py
@@ -1,3 +1,6 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
 import unittest
 
 from aurora_dsql_django.features import DatabaseFeatures

--- a/python/django/aurora_dsql_django/tests/unit/test_operations.py
+++ b/python/django/aurora_dsql_django/tests/unit/test_operations.py
@@ -1,3 +1,6 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
 import unittest
 from unittest.mock import MagicMock
 

--- a/python/django/aurora_dsql_django/tests/unit/test_schema.py
+++ b/python/django/aurora_dsql_django/tests/unit/test_schema.py
@@ -1,3 +1,6 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
 import unittest
 from unittest.mock import MagicMock, patch
 

--- a/python/django/aurora_dsql_django/tests/unit/test_wrapper.py
+++ b/python/django/aurora_dsql_django/tests/unit/test_wrapper.py
@@ -1,3 +1,6 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
 import unittest
 from unittest.mock import MagicMock, patch
 

--- a/python/django/aurora_dsql_django/tests/utils.py
+++ b/python/django/aurora_dsql_django/tests/utils.py
@@ -1,3 +1,6 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
 """Shared test utilities for Aurora DSQL Django tests."""
 
 import django

--- a/python/django/docs/source/conf.py
+++ b/python/django/docs/source/conf.py
@@ -1,5 +1,8 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
 #
 # AuroraDSQL documentation build configuration file, created by
 # sphinx-quickstart on Fri Oct  4 13:54:17 2019.

--- a/python/django/examples/pet-clinic-app/project/manage.py
+++ b/python/django/examples/pet-clinic-app/project/manage.py
@@ -1,15 +1,7 @@
 #!/usr/bin/env python
 
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
-#
-# Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance with
-# the License. A copy of the License is located at
-#
-# http://www.apache.org/licenses/LICENSE-2.0
-#
-# or in the "license" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
-# CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions
-# and limitations under the License.
+# SPDX-License-Identifier: Apache-2.0
 
 """Django's command-line utility for administrative tasks."""
 

--- a/python/django/examples/pet-clinic-app/project/pet_clinic/__init__.py
+++ b/python/django/examples/pet-clinic-app/project/pet_clinic/__init__.py
@@ -1,0 +1,3 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+

--- a/python/django/examples/pet-clinic-app/project/pet_clinic/apps.py
+++ b/python/django/examples/pet-clinic-app/project/pet_clinic/apps.py
@@ -1,13 +1,5 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
-#
-# Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance with
-# the License. A copy of the License is located at
-#
-# http://www.apache.org/licenses/LICENSE-2.0
-#
-# or in the "license" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
-# CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions
-# and limitations under the License.
+# SPDX-License-Identifier: Apache-2.0
 
 from django.apps import AppConfig
 

--- a/python/django/examples/pet-clinic-app/project/pet_clinic/models.py
+++ b/python/django/examples/pet-clinic-app/project/pet_clinic/models.py
@@ -1,13 +1,5 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
-#
-# Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance with
-# the License. A copy of the License is located at
-#
-# http://www.apache.org/licenses/LICENSE-2.0
-#
-# or in the "license" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
-# CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions
-# and limitations under the License.
+# SPDX-License-Identifier: Apache-2.0
 
 import uuid
 

--- a/python/django/examples/pet-clinic-app/project/pet_clinic/tests.py
+++ b/python/django/examples/pet-clinic-app/project/pet_clinic/tests.py
@@ -1,13 +1,5 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
-#
-# Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance with
-# the License. A copy of the License is located at
-#
-# http://www.apache.org/licenses/LICENSE-2.0
-#
-# or in the "license" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
-# CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions
-# and limitations under the License.
+# SPDX-License-Identifier: Apache-2.0
 
 
 # Create your tests here.

--- a/python/django/examples/pet-clinic-app/project/pet_clinic/views.py
+++ b/python/django/examples/pet-clinic-app/project/pet_clinic/views.py
@@ -1,13 +1,5 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
-#
-# Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance with
-# the License. A copy of the License is located at
-#
-# http://www.apache.org/licenses/LICENSE-2.0
-#
-# or in the "license" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
-# CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions
-# and limitations under the License.
+# SPDX-License-Identifier: Apache-2.0
 
 import html
 import json

--- a/python/django/examples/pet-clinic-app/project/project/__init__.py
+++ b/python/django/examples/pet-clinic-app/project/project/__init__.py
@@ -1,0 +1,3 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+

--- a/python/django/examples/pet-clinic-app/project/project/asgi.py
+++ b/python/django/examples/pet-clinic-app/project/project/asgi.py
@@ -1,13 +1,5 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
-#
-# Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance with
-# the License. A copy of the License is located at
-#
-# http://www.apache.org/licenses/LICENSE-2.0
-#
-# or in the "license" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
-# CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions
-# and limitations under the License.
+# SPDX-License-Identifier: Apache-2.0
 
 """
 ASGI config for project project.

--- a/python/django/examples/pet-clinic-app/project/project/settings.py
+++ b/python/django/examples/pet-clinic-app/project/project/settings.py
@@ -1,13 +1,5 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
-#
-# Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance with
-# the License. A copy of the License is located at
-#
-# http://www.apache.org/licenses/LICENSE-2.0
-#
-# or in the "license" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
-# CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions
-# and limitations under the License.
+# SPDX-License-Identifier: Apache-2.0
 
 """
 Django settings for project project.

--- a/python/django/examples/pet-clinic-app/project/project/urls.py
+++ b/python/django/examples/pet-clinic-app/project/project/urls.py
@@ -1,13 +1,5 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
-#
-# Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance with
-# the License. A copy of the License is located at
-#
-# http://www.apache.org/licenses/LICENSE-2.0
-#
-# or in the "license" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
-# CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions
-# and limitations under the License.
+# SPDX-License-Identifier: Apache-2.0
 
 """
 URL configuration for project project.

--- a/python/django/examples/pet-clinic-app/project/project/wsgi.py
+++ b/python/django/examples/pet-clinic-app/project/project/wsgi.py
@@ -1,13 +1,5 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
-#
-# Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance with
-# the License. A copy of the License is located at
-#
-# http://www.apache.org/licenses/LICENSE-2.0
-#
-# or in the "license" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
-# CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions
-# and limitations under the License.
+# SPDX-License-Identifier: Apache-2.0
 
 """
 WSGI config for project project.

--- a/python/django/setup.py
+++ b/python/django/setup.py
@@ -1,3 +1,6 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
 import re
 
 from setuptools import setup


### PR DESCRIPTION
This PR adds copyright headers to the Django source files, in preparation for an upcoming change to the pre-commit checks.

We were previously managing these automatically for other Python projects, but were inconsistently including them manually for Django. I am combining those checks to run at the root level. I've split this change out to make the final diff smaller and isolate header-only changes.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
