### PR TITLE
Wait for CI before releasing

### DIFF
--- a/.github/workflows/java-hibernate-release.yml
+++ b/.github/workflows/java-hibernate-release.yml
@@ -12,7 +12,19 @@ defaults:
     working-directory: java/hibernate/dialect
 
 jobs:
+  wait-for-ci:
+    name: Wait for CI to pass
+    runs-on: ubuntu-latest
+    steps:
+      - uses: lewagon/wait-on-check-action@v1.4.1
+        with:
+          ref: ${{ github.sha }}
+          running-workflow-name: "Wait for CI to pass"
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          wait-interval: 30
+
   deploy:
+    needs: wait-for-ci
     runs-on: ubuntu-latest
     environment: maven
     steps:

--- a/.github/workflows/python-django-release.yml
+++ b/.github/workflows/python-django-release.yml
@@ -12,8 +12,20 @@ defaults:
     working-directory: python/django
 
 jobs:
+  wait-for-ci:
+    name: Wait for CI to pass
+    runs-on: ubuntu-latest
+    steps:
+      - uses: lewagon/wait-on-check-action@v1.4.1
+        with:
+          ref: ${{ github.sha }}
+          running-workflow-name: "Wait for CI to pass"
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          wait-interval: 30
+
   build:
     name: Build distribution
+    needs: wait-for-ci
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6

--- a/.github/workflows/python-sqlalchemy-release.yml
+++ b/.github/workflows/python-sqlalchemy-release.yml
@@ -12,8 +12,20 @@ defaults:
     working-directory: python/sqlalchemy
 
 jobs:
+  wait-for-ci:
+    name: Wait for CI to pass
+    runs-on: ubuntu-latest
+    steps:
+      - uses: lewagon/wait-on-check-action@v1.4.1
+        with:
+          ref: ${{ github.sha }}
+          running-workflow-name: "Wait for CI to pass"
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          wait-interval: 30
+
   build:
     name: Build distribution
+    needs: wait-for-ci
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6

--- a/.github/workflows/python-tortoise-release.yml
+++ b/.github/workflows/python-tortoise-release.yml
@@ -12,8 +12,20 @@ defaults:
     working-directory: python/tortoise-orm
 
 jobs:
+  wait-for-ci:
+    name: Wait for CI to pass
+    runs-on: ubuntu-latest
+    steps:
+      - uses: lewagon/wait-on-check-action@v1.4.1
+        with:
+          ref: ${{ github.sha }}
+          running-workflow-name: "Wait for CI to pass"
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          wait-interval: 30
+
   build:
     name: Build distribution
+    needs: wait-for-ci
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6


### PR DESCRIPTION
This PR adds a `wait-for-ci` job to all release workflows to ensure CI passes before publishing packages.

Previously, pushing a release tag would immediately trigger the build and publish steps, even if CI was failing on that commit. This could result in broken packages being published to PyPI/Maven Central.

Now the release workflows wait for CI to complete successfully before proceeding. This was previously being done for some of the isolated repos, but is now applied to all workflows in the monorepo.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
