### PR TITLE
Configure Dependabot to use uv for Python packages

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,6 +1,6 @@
 version: 2
 updates:
-  - package-ecosystem: "pip"
+  - package-ecosystem: "uv"
     directory: "/python/sqlalchemy"
     schedule:
       interval: "weekly"
@@ -8,11 +8,11 @@ updates:
     directory: "/python/sqlalchemy/examples/pet-clinic-app"
     schedule:
       interval: "weekly"
-  - package-ecosystem: "pip"
+  - package-ecosystem: "uv"
     directory: "/python/tortoise-orm"
     schedule:
       interval: "weekly"
-  - package-ecosystem: "pip"
+  - package-ecosystem: "uv"
     directory: "/python/django"
     schedule:
       interval: "weekly"


### PR DESCRIPTION
This PR updates the Dependabot configuration to also manage the `uv.lock` file for the Python packages.

Currently, updates like #25 are failing because they update the `pyproject.toml` but not the associated `uv.lock` file.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
