### PR TITLE
Configure explicit release name for changelog update task

### DIFF
--- a/.github/workflows/python-django-release.yml
+++ b/.github/workflows/python-django-release.yml
@@ -96,4 +96,5 @@ jobs:
           file: python/django/CHANGELOG.md
           github_token: ${{ secrets.GITHUB_TOKEN }}
           pull_request: true
+          version: ${{ github.ref_name }}
           args: -e ^python/django/

--- a/.github/workflows/python-sqlalchemy-release.yml
+++ b/.github/workflows/python-sqlalchemy-release.yml
@@ -96,4 +96,5 @@ jobs:
           file: python/sqlalchemy/CHANGELOG.md
           github_token: ${{ secrets.GITHUB_TOKEN }}
           pull_request: true
+          version: ${{ github.ref_name }}
           args: -e ^python/sqlalchemy/

--- a/.github/workflows/python-tortoise-release.yml
+++ b/.github/workflows/python-tortoise-release.yml
@@ -96,4 +96,5 @@ jobs:
           file: python/tortoise-orm/CHANGELOG.md
           github_token: ${{ secrets.GITHUB_TOKEN }}
           pull_request: true
+          version: ${{ github.ref_name }}
           args: -e ^python/tortoise-orm/


### PR DESCRIPTION
While #63 correctly updated the SQLAlchemy changelog, the PR and branch name were incorrect.

This seems to be because it pulled the latest release from GitHub metadata, rather than being told what release to use. I have added the `version` configuration field which should correct this.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
