### PR TITLE
Add Prisma to Dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -36,6 +36,14 @@ updates:
     directory: "/java/hibernate/examples/pet-clinic-app"
     schedule:
       interval: "weekly"
+  - package-ecosystem: "npm"
+    directory: "/node/prisma"
+    schedule:
+      interval: "weekly"
+  - package-ecosystem: "npm"
+    directory: "/node/prisma/examples/veterinary-app"
+    schedule:
+      interval: "weekly"
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:


### PR DESCRIPTION
This PR configures Dependabot to monitor dependencies for the Prisma subproject, which was added in #62.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
