### PR TITLE
Apply overrides for Prisma packages in Dependabot alerts

### DIFF
--- a/node/prisma/examples/veterinary-app/package-lock.json
+++ b/node/prisma/examples/veterinary-app/package-lock.json
@@ -5300,9 +5300,9 @@
       }
     },
     "node_modules/hono": {
-      "version": "4.11.4",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.11.4.tgz",
-      "integrity": "sha512-U7tt8JsyrxSRKspfhtLET79pU8K+tInj5QZXs1jSugO1Vq5dFj3kmZsRldo29mTBfcjDRVRXrEZ6LS63Cog9ZA==",
+      "version": "4.11.7",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.11.7.tgz",
+      "integrity": "sha512-l7qMiNee7t82bH3SeyUCt9UF15EVmaBvsppY2zQtrbIhl/yzBTny+YUxsVjSjQ6gaqaeVtZmGocom8TzBlA4Yw==",
       "devOptional": true,
       "license": "MIT",
       "engines": {

--- a/node/prisma/examples/veterinary-app/package.json
+++ b/node/prisma/examples/veterinary-app/package.json
@@ -38,6 +38,13 @@
     "pg": "^8.17.2"
   },
   "overrides": {
-    "lodash": "^4.17.22"
+    "lodash": "^4.17.23",
+    "hono": "^4.11.7"
+  },
+  "comments": {
+    "overrides": {
+      "lodash": "CVE-2025-13465 - Remove when prisma updates to lodash >=4.17.23",
+      "hono": "CVE-2026-24472 - Remove when prisma updates to hono >=4.11.7"
+    }
   }
 }

--- a/node/prisma/package-lock.json
+++ b/node/prisma/package-lock.json
@@ -5432,9 +5432,9 @@
       }
     },
     "node_modules/hono": {
-      "version": "4.11.4",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.11.4.tgz",
-      "integrity": "sha512-U7tt8JsyrxSRKspfhtLET79pU8K+tInj5QZXs1jSugO1Vq5dFj3kmZsRldo29mTBfcjDRVRXrEZ6LS63Cog9ZA==",
+      "version": "4.11.7",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.11.7.tgz",
+      "integrity": "sha512-l7qMiNee7t82bH3SeyUCt9UF15EVmaBvsppY2zQtrbIhl/yzBTny+YUxsVjSjQ6gaqaeVtZmGocom8TzBlA4Yw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -6503,9 +6503,9 @@
       }
     },
     "node_modules/lodash": {
-      "version": "4.17.21",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+      "version": "4.17.23",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.23.tgz",
+      "integrity": "sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==",
       "dev": true,
       "license": "MIT"
     },

--- a/node/prisma/package.json
+++ b/node/prisma/package.json
@@ -51,5 +51,15 @@
     "ts-jest": "^29.4.1",
     "tsx": "^4.20.3",
     "typescript": "^5.8.3"
+  },
+  "overrides": {
+    "lodash": "^4.17.23",
+    "hono": "^4.11.7"
+  },
+  "comments": {
+    "overrides": {
+      "lodash": "CVE-2025-13465 - Remove when prisma updates to lodash >=4.17.23",
+      "hono": "CVE-2026-24472 - Remove when prisma updates to hono >=4.11.7"
+    }
   }
 }


### PR DESCRIPTION
This PR fixes a few Dependabot security warnings by overriding the used package versions to patched ones. These transitive dependencies are provided by Prisma, but haven't been updated upstream yet.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
