### PR TITLE
Use local prettier for prisma to keep versions synced

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -24,5 +24,11 @@ jobs:
           java-version: "17"
           distribution: "corretto"
 
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+
+      - run: npm ci --prefix node/prisma
+
       - name: Run pre-commit
         run: uvx pre-commit run --all-files

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -80,7 +80,7 @@ repos:
     hooks:
       - id: prettier-prisma
         name: prettier (prisma)
-        entry: npx --prefix node/prisma prettier --write
+        entry: npx --prefix node/prisma --no prettier --write
         language: system
         files: ^node/prisma/
         types_or: [ts, javascript, json]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -74,8 +74,14 @@ repos:
     hooks:
       - id: prettier
         types: [yaml]
-      - id: prettier
+
+  # Prisma formatting (uses prettier from node/prisma package.json)
+  - repo: local
+    hooks:
+      - id: prettier-prisma
         name: prettier (prisma)
+        entry: npx --prefix node/prisma prettier --write
+        language: system
         files: ^node/prisma/
         types_or: [ts, javascript, json]
 


### PR DESCRIPTION
This PR updates the pre-commit hooks to use the prettier version specified by the Prisma `package.json`. The hook uses `npx` which should be cross-platform.

This avoids changes like #68 breaking the synchronization between these versions.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
