### PR TITLE
Fix Python publishing metadata

### DIFF
--- a/python/django/pyproject.toml
+++ b/python/django/pyproject.toml
@@ -1,12 +1,12 @@
 [build-system]
-requires = ["hatchling", "hatch-vcs"]
+requires = ["hatchling", "hatch-vcs", "hatch-fancy-pypi-readme"]
 build-backend = "hatchling.build"
 
 [project]
 name = "aurora_dsql_django"
 dynamic = ["version", "readme"]
 description = "Aurora DSQL adapter for Django"
-license-files = ["LICENSE"]
+license = "Apache-2.0"
 authors = [{name = "Amazon Web Services"}]
 requires-python = ">=3.10"
 dependencies = [
@@ -61,6 +61,16 @@ raw-options = { root = "../..", git_describe_command = ["git", "describe", "--ta
 
 [tool.hatch.build.hooks.vcs]
 version-file = "aurora_dsql_django/_version.py"
+
+[tool.hatch.metadata.hooks.fancy-pypi-readme]
+content-type = "text/markdown"
+
+[[tool.hatch.metadata.hooks.fancy-pypi-readme.fragments]]
+path = "README.md"
+
+[[tool.hatch.metadata.hooks.fancy-pypi-readme.substitutions]]
+pattern = '\[([^\]]+)\]\((?!https?://)([^)]+)\)'
+replacement = '[\1](https://github.com/awslabs/aurora-dsql-orms/blob/python/django/v$HFPR_VERSION/python/django/\2)'
 
 [tool.hatch.build.targets.wheel]
 packages = ["aurora_dsql_django"]

--- a/python/sqlalchemy/README.md
+++ b/python/sqlalchemy/README.md
@@ -13,8 +13,8 @@ Aurora DSQL's distributed architecture and high availability.
 
 ## Sample Application
 
-There is an included sample application in [examples/pet-clinic-app](https://github.com/awslabs/aurora-dsql-orms/tree/main/python/sqlalchemy/examples/pet-clinic-app) that shows how to use Aurora DSQL
-with SQLAlchemy. To run the included example please refer to the [sample README](https://github.com/awslabs/aurora-dsql-orms/tree/main/python/sqlalchemy/examples/pet-clinic-app#readme).
+There is an included sample application in [examples/pet-clinic-app](examples/pet-clinic-app) that shows how to use Aurora DSQL
+with SQLAlchemy. To run the included example please refer to the [sample README](examples/pet-clinic-app#readme).
 
 ## Prerequisites
 
@@ -146,11 +146,11 @@ Column(
 
 ## Developer instructions
 
-Instructions on how to build and test the dialect are available in the [Developer Instructions](https://github.com/awslabs/aurora-dsql-orms/tree/main/python/sqlalchemy/aurora_dsql_sqlalchemy#readme).
+Instructions on how to build and test the dialect are available in the [Developer Instructions](aurora_dsql_sqlalchemy/README.md).
 
 ## Security
 
-See [CONTRIBUTING](https://github.com/awslabs/aurora-dsql-orms/blob/main/CONTRIBUTING.md#security-issue-notifications) for more information.
+See [CONTRIBUTING](../../CONTRIBUTING.md#security-issue-notifications) for more information.
 
 ## License
 

--- a/python/sqlalchemy/pyproject.toml
+++ b/python/sqlalchemy/pyproject.toml
@@ -1,14 +1,13 @@
 [build-system]
-requires = ["hatchling", "hatch-vcs"]
+requires = ["hatchling", "hatch-vcs", "hatch-fancy-pypi-readme"]
 build-backend = "hatchling.build"
 
 [project]
 name = "aurora-dsql-sqlalchemy"
-dynamic = ["version"]
+dynamic = ["version", "readme"]
 description = "Amazon Aurora DSQL dialect for SQLAlchemy"
 authors = [{name = "Amazon Web Services"}]
-license = {text = "Apache License 2.0"}
-readme = "README.md"
+license = "Apache-2.0"
 requires-python = ">=3.10"
 dependencies = [
     "sqlalchemy>=2.0.0",
@@ -62,6 +61,16 @@ raw-options = { root = "../..", git_describe_command = ["git", "describe", "--ta
 
 [tool.hatch.build.hooks.vcs]
 version-file = "aurora_dsql_sqlalchemy/_version.py"
+
+[tool.hatch.metadata.hooks.fancy-pypi-readme]
+content-type = "text/markdown"
+
+[[tool.hatch.metadata.hooks.fancy-pypi-readme.fragments]]
+path = "README.md"
+
+[[tool.hatch.metadata.hooks.fancy-pypi-readme.substitutions]]
+pattern = '\[([^\]]+)\]\((?!https?://)([^)]+)\)'
+replacement = '[\1](https://github.com/awslabs/aurora-dsql-orms/blob/python/sqlalchemy/v$HFPR_VERSION/python/sqlalchemy/\2)'
 
 [tool.hatch.build.targets.wheel]
 packages = ["aurora_dsql_sqlalchemy"]

--- a/python/tortoise-orm/pyproject.toml
+++ b/python/tortoise-orm/pyproject.toml
@@ -1,9 +1,8 @@
 [project]
 name = "aurora-dsql-tortoise-orm"
-dynamic = ["version"]
-readme = "README.md"
+dynamic = ["version", "readme"]
 description = "Aurora DSQL adapter for Tortoise ORM"
-license-files = ["LICENSE"]
+license = "Apache-2.0"
 authors = [{name = "Amazon Web Services"}]
 
 requires-python = ">=3.10"
@@ -47,7 +46,7 @@ dev = [
 ]
 
 [build-system]
-requires = ["hatchling", "hatch-vcs"]
+requires = ["hatchling", "hatch-vcs", "hatch-fancy-pypi-readme"]
 build-backend = "hatchling.build"
 
 [tool.hatch.version]
@@ -57,6 +56,16 @@ raw-options = { root = "../..", git_describe_command = ["git", "describe", "--ta
 
 [tool.hatch.build.hooks.vcs]
 version-file = "aurora_dsql_tortoise/_version.py"
+
+[tool.hatch.metadata.hooks.fancy-pypi-readme]
+content-type = "text/markdown"
+
+[[tool.hatch.metadata.hooks.fancy-pypi-readme.fragments]]
+path = "README.md"
+
+[[tool.hatch.metadata.hooks.fancy-pypi-readme.substitutions]]
+pattern = '\[([^\]]+)\]\((?!https?://)([^)]+)\)'
+replacement = '[\1](https://github.com/awslabs/aurora-dsql-orms/blob/python/tortoise-orm/v$HFPR_VERSION/python/tortoise-orm/\2)'
 
 [tool.hatch.build.targets.wheel]
 packages = ["aurora_dsql_tortoise"]


### PR DESCRIPTION
This PR fixes a few metadata issues for the Python packages in this project, to ensure the data shown on PyPI during publishing is correct.

Currently:
- The referenced `LICENSE` file doesn't exist
- SQLAlchemy uses the old free-form way to specify the license instead of a SPDX identifier
- The `README.md` file is not being published for Django (as can be seen in [0.4.0](https://test.pypi.org/project/aurora-dsql-django/0.4.0/))
- The other projects reference the `README.md` in a way that requires full URLs which are hard to maintain and easy to mess up

The change here fixes the licenses for all projects, and uses a hook to update local paths to fully qualified links which will work when clicked from PyPI. The local paths are easier to maintain in the repo, and will work for people with cloned copies in an IDE.

This is conceptually similar to https://github.com/awslabs/aurora-dsql-tortoise-orm/pull/24 but I used a community plugin since I couldn't figure out a simple way to share the hook across the 3 Python packages and didn't want to duplicate the hook code. That is always an option in the future if we can figure out the build issues with parent path references and want to switch.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
