### PR TITLE
Add fast-xml-parser version override for Dependabot alert

### DIFF
--- a/node/prisma/examples/veterinary-app/package-lock.json
+++ b/node/prisma/examples/veterinary-app/package-lock.json
@@ -5034,9 +5034,9 @@
       "license": "MIT"
     },
     "node_modules/fast-xml-parser": {
-      "version": "5.2.5",
-      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.2.5.tgz",
-      "integrity": "sha512-pfX9uG9Ki0yekDHx2SiuRIyFdyAr1kMIMitPvb0YBo8SUfKvia7w7FIyd/l6av85pFYRhZscS75MwMnbvY+hcQ==",
+      "version": "5.3.4",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.3.4.tgz",
+      "integrity": "sha512-EFd6afGmXlCx8H8WTZHhAoDaWaGyuIBoZJ2mknrNxug+aZKjkp0a0dlars9Izl+jF+7Gu1/5f/2h68cQpe0IiA==",
       "funding": [
         {
           "type": "github",

--- a/node/prisma/examples/veterinary-app/package.json
+++ b/node/prisma/examples/veterinary-app/package.json
@@ -39,12 +39,14 @@
   },
   "overrides": {
     "lodash": "^4.17.23",
-    "hono": "^4.11.7"
+    "hono": "^4.11.7",
+    "fast-xml-parser": "^5.3.4"
   },
   "comments": {
     "overrides": {
       "lodash": "CVE-2025-13465 - Remove when prisma updates to lodash >=4.17.23",
-      "hono": "CVE-2026-24472 - Remove when prisma updates to hono >=4.11.7"
+      "hono": "CVE-2026-24472 - Remove when prisma updates to hono >=4.11.7",
+      "fast-xml-parser": "CVE-2026-25128 - Remove when @aws-sdk/xml-builder updates to fast-xml-parser >=5.3.4"
     }
   }
 }


### PR DESCRIPTION
This PR adds an override for the `fast-xml-parser` version to fix a Dependabot alert which can't be upgraded otherwise since it is a transitive dependency from the AWS SDK. The upstream package has not been updated yet to include the patched version.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
