### PR TITLE
Add explicit version to hibernate dialect publish workflow

### DIFF
--- a/.github/workflows/java-hibernate-release.yml
+++ b/.github/workflows/java-hibernate-release.yml
@@ -65,4 +65,5 @@ jobs:
           file: java/hibernate/CHANGELOG.md
           github_token: ${{ secrets.GITHUB_TOKEN }}
           pull_request: true
+          version: ${{ github.ref_name }}
           args: -e ^java/hibernate/


### PR DESCRIPTION
This PR adds an explicit `version` configuration to the task which updates the hibernate dialect changelog.

This should have been included in #64 but was missed. See #78 for an example of what happens without this.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
