### PR TITLE
Ignore incompatible dependabot upgrades

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -28,14 +28,31 @@ updates:
     directory: "/java/hibernate/dialect"
     schedule:
       interval: "weekly"
+    ignore:
+      # Hibernate 7 has breaking API changes incompatible with this dialect
+      - dependency-name: "org.hibernate:hibernate-core"
+        versions: [">=7"]
+      - dependency-name: "org.hibernate.orm:hibernate-ant"
+        versions: [">=7"]
   - package-ecosystem: "gradle"
     directory: "/java/hibernate/examples/pet-clinic-app"
     schedule:
       interval: "weekly"
+    ignore:
+      # Hibernate 7 has breaking API changes incompatible with this dialect
+      - dependency-name: "org.hibernate:hibernate-core"
+        versions: [">=7"]
   - package-ecosystem: "maven"
     directory: "/java/hibernate/examples/pet-clinic-app"
     schedule:
       interval: "weekly"
+    ignore:
+      # Hibernate 7 has breaking API changes incompatible with this dialect
+      - dependency-name: "org.hibernate:hibernate-core"
+        versions: [">=7"]
+      # Checkstyle 13+ requires Java 21, but this project targets Java 17
+      - dependency-name: "com.puppycrawl.tools:checkstyle"
+        versions: [">=13"]
   - package-ecosystem: "npm"
     directory: "/node/prisma"
     schedule:


### PR DESCRIPTION
This PR configures dependabot to ignore specific upgrades which are known to be incompatible:

- Hibernate 7+ has breaking API changes which are not compatible with this dialect in its current form
- Checkstyle 13+ requires Java 21, and this project is building/testing with Java 17

This should prevent failed dependabot PRs such as #83, #84, #86, #94

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
