### PR TITLE
Add combined CI gate workflow for required GH check

### DIFF
--- a/.github/workflows/ci-gate.yml
+++ b/.github/workflows/ci-gate.yml
@@ -1,0 +1,127 @@
+# Orchestrates all PR CI by detecting changed paths and conditionally invoking
+# per-language workflows. The "gate" job always runs and can be configured as
+# the single required status check in GitHub branch protection.
+name: CI Gate
+
+permissions: {}
+
+on:
+  pull_request:
+
+jobs:
+  changes:
+    runs-on: ubuntu-latest
+    outputs:
+      java-hibernate: ${{ steps.detect.outputs.java-hibernate }}
+      node-prisma: ${{ steps.detect.outputs.node-prisma }}
+      python-django: ${{ steps.detect.outputs.python-django }}
+      python-sqlalchemy: ${{ steps.detect.outputs.python-sqlalchemy }}
+      python-tortoise: ${{ steps.detect.outputs.python-tortoise }}
+    steps:
+      - uses: actions/github-script@v7
+        id: detect
+        with:
+          script: |
+            const config = {
+              'java-hibernate': ['java/hibernate/'],
+              'node-prisma': ['node/prisma/'],
+              'python-django': ['python/django/'],
+              'python-sqlalchemy': ['python/sqlalchemy/'],
+              'python-tortoise': ['python/tortoise-orm/'],
+            };
+            const runAllPaths = [
+              '.github/',
+              '.pre-commit-config.yaml',
+              'pyproject.toml'
+            ];
+
+            const pr = context.payload.pull_request;
+
+            let files = [];
+            const paginator = github.paginate.iterator(github.rest.pulls.listFiles, {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: pr.number,
+              per_page: 100,
+            });
+            for await (const resp of paginator) {
+              files.push(...resp.data.map(f => f.filename));
+            }
+
+            // If API truncated results, run everything to be safe
+            let runAll = files.length < pr.changed_files;
+
+            if (!runAll) {
+              runAll = files.some(f => runAllPaths.some(p => f === p || f.startsWith(p)));
+            }
+
+            for (const [name, paths] of Object.entries(config)) {
+              const shouldRun = runAll || files.some(f => paths.some(p => f.startsWith(p)));
+              core.setOutput(name, String(shouldRun));
+            }
+
+  pre-commit:
+    needs: changes
+    uses: ./.github/workflows/pre-commit.yml
+
+  java-hibernate:
+    needs: changes
+    if: needs.changes.outputs.java-hibernate == 'true'
+    uses: ./.github/workflows/java-hibernate-ci.yml
+    secrets: inherit
+    permissions:
+      id-token: write # required by aws-actions/configure-aws-credentials
+
+  node-prisma:
+    needs: changes
+    if: needs.changes.outputs.node-prisma == 'true'
+    uses: ./.github/workflows/node-prisma-ci.yml
+    secrets: inherit
+    permissions:
+      id-token: write # required by aws-actions/configure-aws-credentials
+
+  python-django:
+    needs: changes
+    if: needs.changes.outputs.python-django == 'true'
+    uses: ./.github/workflows/python-django-ci.yml
+    secrets: inherit
+    permissions:
+      id-token: write # required by aws-actions/configure-aws-credentials
+
+  python-sqlalchemy:
+    needs: changes
+    if: needs.changes.outputs.python-sqlalchemy == 'true'
+    uses: ./.github/workflows/python-sqlalchemy-ci.yml
+    secrets: inherit
+    permissions:
+      id-token: write # required by aws-actions/configure-aws-credentials
+
+  python-tortoise:
+    needs: changes
+    if: needs.changes.outputs.python-tortoise == 'true'
+    uses: ./.github/workflows/python-tortoise-ci.yml
+    secrets: inherit
+    permissions:
+      id-token: write # required by aws-actions/configure-aws-credentials
+
+  gate:
+    name: gate
+    runs-on: ubuntu-latest
+    needs:
+      - pre-commit
+      - java-hibernate
+      - python-django
+      - python-sqlalchemy
+      - python-tortoise
+      - node-prisma
+    if: always()
+    steps:
+      - uses: actions/github-script@v7
+        with:
+          script: |
+            const needs = ${{ toJSON(needs) }};
+            for (const [job, result] of Object.entries(needs)) {
+              if (result.result === 'failure' || result.result === 'cancelled') {
+                core.setFailed(`Job ${job} ${result.result}`);
+              }
+            }

--- a/.github/workflows/dependabot-automerge.yml
+++ b/.github/workflows/dependabot-automerge.yml
@@ -1,0 +1,26 @@
+# Auto-approves and enables squash merge for Dependabot PRs.
+# Merge occurs after CI Gate passes.
+name: Dependabot Auto-merge
+
+permissions: {}
+
+on:
+  pull_request:
+
+jobs:
+  automerge:
+    if: github.event.pull_request.user.login == 'dependabot[bot]'
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write # required to approve PR
+      contents: write # required to enable auto-merge
+    steps:
+      - uses: dependabot/fetch-metadata@v2
+
+      - name: Approve and enable auto-merge
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh pr review --approve "$PR_URL"
+          gh pr merge --auto --squash "$PR_URL"

--- a/.github/workflows/java-hibernate-ci.yml
+++ b/.github/workflows/java-hibernate-ci.yml
@@ -3,19 +3,10 @@ name: Hibernate CI
 permissions: {}
 
 on:
+  workflow_call: {}
+  workflow_dispatch:
   push:
     branches: [main]
-    paths:
-      - "java/hibernate/**"
-      - ".github/workflows/java-hibernate-ci.yml"
-      - ".github/workflows/dsql-cluster-*.yml"
-  pull_request:
-    branches: [main]
-    paths:
-      - "java/hibernate/**"
-      - ".github/workflows/java-hibernate-ci.yml"
-      - ".github/workflows/dsql-cluster-*.yml"
-  workflow_dispatch:
 
 jobs:
   build:

--- a/.github/workflows/node-prisma-ci.yml
+++ b/.github/workflows/node-prisma-ci.yml
@@ -3,19 +3,10 @@ name: Node Prisma CI
 permissions: {}
 
 on:
+  workflow_call: {}
+  workflow_dispatch:
   push:
     branches: [main]
-    paths:
-      - "node/prisma/**"
-      - ".github/workflows/node-prisma-ci.yml"
-      - ".github/workflows/dsql-cluster-*.yml"
-  pull_request:
-    branches: [main]
-    paths:
-      - "node/prisma/**"
-      - ".github/workflows/node-prisma-ci.yml"
-      - ".github/workflows/dsql-cluster-*.yml"
-  workflow_dispatch:
 
 defaults:
   run:

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -3,11 +3,10 @@ name: Pre-commit
 permissions: {}
 
 on:
+  workflow_call: {}
+  workflow_dispatch:
   push:
     branches: [main]
-  pull_request:
-    branches: [main]
-  workflow_dispatch:
 
 jobs:
   pre-commit:

--- a/.github/workflows/python-django-ci.yml
+++ b/.github/workflows/python-django-ci.yml
@@ -3,19 +3,10 @@ name: Django CI
 permissions: {}
 
 on:
+  workflow_call: {}
+  workflow_dispatch:
   push:
     branches: [main]
-    paths:
-      - "python/django/**"
-      - ".github/workflows/python-django-ci.yml"
-      - ".github/workflows/dsql-cluster-*.yml"
-  pull_request:
-    branches: [main]
-    paths:
-      - "python/django/**"
-      - ".github/workflows/python-django-ci.yml"
-      - ".github/workflows/dsql-cluster-*.yml"
-  workflow_dispatch:
 
 defaults:
   run:

--- a/.github/workflows/python-sqlalchemy-ci.yml
+++ b/.github/workflows/python-sqlalchemy-ci.yml
@@ -3,19 +3,10 @@ name: SQLAlchemy CI
 permissions: {}
 
 on:
+  workflow_call: {}
+  workflow_dispatch:
   push:
     branches: [main]
-    paths:
-      - "python/sqlalchemy/**"
-      - ".github/workflows/python-sqlalchemy-ci.yml"
-      - ".github/workflows/dsql-cluster-*.yml"
-  pull_request:
-    branches: [main]
-    paths:
-      - "python/sqlalchemy/**"
-      - ".github/workflows/python-sqlalchemy-ci.yml"
-      - ".github/workflows/dsql-cluster-*.yml"
-  workflow_dispatch:
 
 defaults:
   run:

--- a/.github/workflows/python-tortoise-ci.yml
+++ b/.github/workflows/python-tortoise-ci.yml
@@ -3,19 +3,10 @@ name: Tortoise ORM CI
 permissions: {}
 
 on:
+  workflow_call: {}
+  workflow_dispatch:
   push:
     branches: [main]
-    paths:
-      - "python/tortoise-orm/**"
-      - ".github/workflows/python-tortoise-ci.yml"
-      - ".github/workflows/dsql-cluster-*.yml"
-  pull_request:
-    branches: [main]
-    paths:
-      - "python/tortoise-orm/**"
-      - ".github/workflows/python-tortoise-ci.yml"
-      - ".github/workflows/dsql-cluster-*.yml"
-  workflow_dispatch:
 
 defaults:
   run:


### PR DESCRIPTION
This PR provides a unified CI job which provides a single, stable required check regardless of which paths changed in a PR. It also enables automerge for dependabot PRs to ease the maintenance burden. The unified CI job is necessary as GitHub requires a stable job that runs for every PR in order to configure a required check.

We want the CI checks to be required before merge, as otherwise it is possible to merge a PR with failing checks or before the checks are triggered if you are fast enough. Auto-merged dependabot PRs in particular may encounter this without a required check.

The current setup requires per-package CI checks (e.g., Hibernate CI, Django CI), but these only run when their respective paths change. These checks couldn't be configured as "required checks" in GitHub, as they would block any other package changes from being merged due to not triggering on the unrelated change paths.

To solve this, I have made the following changes:

- New `ci-gate.yml` workflow handles all PR CI. It detects changed paths and conditionally invokes the appropriate language workflows.
- The gate job always runs and aggregates results, providing one predictable status check for branch protection rules.

I have added a new `dependabot-automerge.yml` workflow which auto-approves Dependabot PRs and enables squash merge. Merge occurs only after the required gate passes.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
