### PR TITLE
Tweak CI workflow and dependabot config after testing

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,31 +3,31 @@ updates:
   - package-ecosystem: "uv"
     directory: "/python/sqlalchemy"
     schedule:
-      interval: "weekly"
+      interval: "daily"
   - package-ecosystem: "pip"
     directory: "/python/sqlalchemy/examples/pet-clinic-app"
     schedule:
-      interval: "weekly"
+      interval: "daily"
   - package-ecosystem: "uv"
     directory: "/python/tortoise-orm"
     schedule:
-      interval: "weekly"
+      interval: "daily"
   - package-ecosystem: "uv"
     directory: "/python/django"
     schedule:
-      interval: "weekly"
+      interval: "daily"
   - package-ecosystem: "pip"
     directory: "/python/django/examples/pet-clinic-app"
     schedule:
-      interval: "weekly"
+      interval: "daily"
   - package-ecosystem: "gradle"
     directory: "/java/flyway"
     schedule:
-      interval: "weekly"
+      interval: "daily"
   - package-ecosystem: "gradle"
     directory: "/java/hibernate/dialect"
     schedule:
-      interval: "weekly"
+      interval: "daily"
     ignore:
       # Hibernate 7 has breaking API changes incompatible with this dialect
       - dependency-name: "org.hibernate:hibernate-core"
@@ -37,7 +37,7 @@ updates:
   - package-ecosystem: "gradle"
     directory: "/java/hibernate/examples/pet-clinic-app"
     schedule:
-      interval: "weekly"
+      interval: "daily"
     ignore:
       # Hibernate 7 has breaking API changes incompatible with this dialect
       - dependency-name: "org.hibernate:hibernate-core"
@@ -45,7 +45,7 @@ updates:
   - package-ecosystem: "maven"
     directory: "/java/hibernate/examples/pet-clinic-app"
     schedule:
-      interval: "weekly"
+      interval: "daily"
     ignore:
       # Hibernate 7 has breaking API changes incompatible with this dialect
       - dependency-name: "org.hibernate:hibernate-core"
@@ -56,12 +56,12 @@ updates:
   - package-ecosystem: "npm"
     directory: "/node/prisma"
     schedule:
-      interval: "weekly"
+      interval: "daily"
   - package-ecosystem: "npm"
     directory: "/node/prisma/examples/veterinary-app"
     schedule:
-      interval: "weekly"
+      interval: "daily"
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      interval: "weekly"
+      interval: "daily"

--- a/.github/workflows/ci-gate.yml
+++ b/.github/workflows/ci-gate.yml
@@ -7,6 +7,7 @@ permissions: {}
 
 on:
   pull_request:
+  workflow_dispatch:
 
 jobs:
   changes:
@@ -23,19 +24,29 @@ jobs:
         with:
           script: |
             const config = {
-              'java-hibernate': ['java/hibernate/'],
-              'node-prisma': ['node/prisma/'],
-              'python-django': ['python/django/'],
-              'python-sqlalchemy': ['python/sqlalchemy/'],
-              'python-tortoise': ['python/tortoise-orm/'],
+              'java-hibernate': ['java/hibernate/', '.github/workflows/java-hibernate-ci.yml'],
+              'node-prisma': ['node/prisma/', '.github/workflows/node-prisma-ci.yml'],
+              'python-django': ['python/django/', '.github/workflows/python-django-ci.yml'],
+              'python-sqlalchemy': ['python/sqlalchemy/', '.github/workflows/python-sqlalchemy-ci.yml'],
+              'python-tortoise': ['python/tortoise-orm/', '.github/workflows/python-tortoise-ci.yml'],
             };
             const runAllPaths = [
-              '.github/',
+              '.github/workflows/ci-gate.yml',
+              '.github/workflows/dsql-cluster-create.yml',
+              '.github/workflows/dsql-cluster-delete.yml',
               '.pre-commit-config.yaml',
               'pyproject.toml'
             ];
 
             const pr = context.payload.pull_request;
+
+            // Manual dispatch: run all CI
+            if (!pr) {
+              for (const name of Object.keys(config)) {
+                core.setOutput(name, 'true');
+              }
+              return;
+            }
 
             let files = [];
             const paginator = github.paginate.iterator(github.rest.pulls.listFiles, {

--- a/.github/workflows/ci-gate.yml
+++ b/.github/workflows/ci-gate.yml
@@ -35,7 +35,6 @@ jobs:
               '.github/workflows/dsql-cluster-create.yml',
               '.github/workflows/dsql-cluster-delete.yml',
               '.pre-commit-config.yaml',
-              'pyproject.toml'
             ];
 
             const pr = context.payload.pull_request;


### PR DESCRIPTION
This PR provides a few tweaks following testing of the changes in #105

- Switch dependabot from "weekly" to "daily" monitoring. Now changes are tested and merged automatically, the frequency isn't as important and daily will help avoid batching of changes.
- Only run changed workflows where possible rather than triggering all workflows any time one changed
- Allow manually triggering CI for a particular commit to help with debugging
- Remove `pyproject.toml` from the `runAllPaths` list given there isn't one in the root dir


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
