### PR TITLE
Use OIDC for node-prisma npm publishing

### DIFF
--- a/.github/workflows/node-prisma-release.yml
+++ b/.github/workflows/node-prisma-release.yml
@@ -50,9 +50,7 @@ jobs:
         run: npm run build
 
       - name: Publish to npm
-        run: npm publish --provenance
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: npm publish
 
   update-changelog:
     name: Update changelog


### PR DESCRIPTION
## Summary

Remove NPM_TOKEN fallback now that trusted publishing is configured on npm.

## Changes

- Removed `NODE_AUTH_TOKEN` env var from publish step
- Workflow now uses pure OIDC authentication

## Test plan

- [ ] Merge PR
- [ ] Create v0.1.1 release to test OIDC publishing