### PR TITLE
Use BOT_GITHUB_TOKEN for updating release notes

### DIFF
--- a/.github/workflows/java-hibernate-release.yml
+++ b/.github/workflows/java-hibernate-release.yml
@@ -50,20 +50,8 @@ jobs:
           JRELEASER_MAVENCENTRAL_PASSWORD: ${{ secrets.SONATYPE_PASSWORD }}
 
   update-changelog:
-    name: Update changelog
     needs: deploy
-    runs-on: ubuntu-latest
-    permissions:
-      contents: write # required by rhysd/changelog-from-release/action
-      pull-requests: write # required by rhysd/changelog-from-release/action
-    steps:
-      - uses: actions/checkout@v6
-        with:
-          ref: main
-      - uses: rhysd/changelog-from-release/action@v3
-        with:
-          file: java/hibernate/CHANGELOG.md
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          pull_request: true
-          version: ${{ github.ref_name }}
-          args: -e ^java/hibernate/
+    uses: ./.github/workflows/update-changelog.yml
+    with:
+      tag: ${{ github.ref_name }}
+    secrets: inherit

--- a/.github/workflows/node-prisma-release.yml
+++ b/.github/workflows/node-prisma-release.yml
@@ -53,20 +53,8 @@ jobs:
         run: npm publish
 
   update-changelog:
-    name: Update changelog
     needs: publish-to-npm
-    runs-on: ubuntu-latest
-    permissions:
-      contents: write # required by rhysd/changelog-from-release/action
-      pull-requests: write # required by rhysd/changelog-from-release/action
-    steps:
-      - uses: actions/checkout@v6
-        with:
-          ref: main
-      - uses: rhysd/changelog-from-release/action@v3
-        with:
-          file: node/prisma/CHANGELOG.md
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          pull_request: true
-          version: ${{ github.ref_name }}
-          args: -e ^node/prisma/
+    uses: ./.github/workflows/update-changelog.yml
+    with:
+      tag: ${{ github.ref_name }}
+    secrets: inherit

--- a/.github/workflows/python-django-release.yml
+++ b/.github/workflows/python-django-release.yml
@@ -81,20 +81,8 @@ jobs:
       - uses: pypa/gh-action-pypi-publish@release/v1
 
   update-changelog:
-    name: Update changelog
     needs: publish-to-pypi
-    runs-on: ubuntu-latest
-    permissions:
-      contents: write # required by rhysd/changelog-from-release/action
-      pull-requests: write # required by rhysd/changelog-from-release/action
-    steps:
-      - uses: actions/checkout@v6
-        with:
-          ref: main
-      - uses: rhysd/changelog-from-release/action@v3
-        with:
-          file: python/django/CHANGELOG.md
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          pull_request: true
-          version: ${{ github.ref_name }}
-          args: -e ^python/django/
+    uses: ./.github/workflows/update-changelog.yml
+    with:
+      tag: ${{ github.ref_name }}
+    secrets: inherit

--- a/.github/workflows/python-sqlalchemy-release.yml
+++ b/.github/workflows/python-sqlalchemy-release.yml
@@ -81,20 +81,8 @@ jobs:
       - uses: pypa/gh-action-pypi-publish@release/v1
 
   update-changelog:
-    name: Update changelog
     needs: publish-to-pypi
-    runs-on: ubuntu-latest
-    permissions:
-      contents: write # required by rhysd/changelog-from-release/action
-      pull-requests: write # required by rhysd/changelog-from-release/action
-    steps:
-      - uses: actions/checkout@v6
-        with:
-          ref: main
-      - uses: rhysd/changelog-from-release/action@v3
-        with:
-          file: python/sqlalchemy/CHANGELOG.md
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          pull_request: true
-          version: ${{ github.ref_name }}
-          args: -e ^python/sqlalchemy/
+    uses: ./.github/workflows/update-changelog.yml
+    with:
+      tag: ${{ github.ref_name }}
+    secrets: inherit

--- a/.github/workflows/python-tortoise-release.yml
+++ b/.github/workflows/python-tortoise-release.yml
@@ -81,20 +81,8 @@ jobs:
       - uses: pypa/gh-action-pypi-publish@release/v1
 
   update-changelog:
-    name: Update changelog
     needs: publish-to-pypi
-    runs-on: ubuntu-latest
-    permissions:
-      contents: write # required by rhysd/changelog-from-release/action
-      pull-requests: write # required by rhysd/changelog-from-release/action
-    steps:
-      - uses: actions/checkout@v6
-        with:
-          ref: main
-      - uses: rhysd/changelog-from-release/action@v3
-        with:
-          file: python/tortoise-orm/CHANGELOG.md
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          pull_request: true
-          version: ${{ github.ref_name }}
-          args: -e ^python/tortoise-orm/
+    uses: ./.github/workflows/update-changelog.yml
+    with:
+      tag: ${{ github.ref_name }}
+    secrets: inherit

--- a/.github/workflows/update-changelog.yml
+++ b/.github/workflows/update-changelog.yml
@@ -1,0 +1,44 @@
+name: Update Changelog
+
+permissions: {}
+
+on:
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Tag name (e.g., python/django/v1.0.0)"
+        required: true
+        type: string
+  workflow_call:
+    inputs:
+      tag:
+        required: true
+        type: string
+
+jobs:
+  update-changelog:
+    name: Update changelog
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write # required by rhysd/changelog-from-release/action
+      pull-requests: write # required by rhysd/changelog-from-release/action
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: main
+
+      - name: Determine changelog file
+        id: changelog
+        run: |
+          TAG="${{ inputs.tag }}"
+          PREFIX="${TAG%/v*}"
+          echo "file=${PREFIX}/CHANGELOG.md" >> "$GITHUB_OUTPUT"
+          echo "filter=^${PREFIX}/" >> "$GITHUB_OUTPUT"
+
+      - uses: rhysd/changelog-from-release/action@v3
+        with:
+          file: ${{ steps.changelog.outputs.file }}
+          github_token: ${{ secrets.BOT_GITHUB_TOKEN }}
+          pull_request: true
+          version: ${{ inputs.tag }}
+          args: -e ${{ steps.changelog.outputs.filter }}


### PR DESCRIPTION
This PR modifies the changelog update workflow to use `BOT_GITHUB_TOKEN`, which is a PAT owned by the DSQL bot account.

This is necessary because the default `github-actions` bot account cannot trigger workflows for generated PRs, I think as a measure to prevent loops of actions that trigger each other. You need a PAT set up to trigger the workflows properly, but we don't want to tie the workflows to an individual, hence the use of the shared account. The workflow triggering problem can be seen in #108 as an example.

I also moved the changelog update task definition to a shared workflow, and added `workflow_dispatch` so it can be manually triggered for debugging purposes, and to help fix any changelog updates that fail during deployments.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
