### PR TITLE
Add maven to .mise.toml

### DIFF
--- a/.mise.toml
+++ b/.mise.toml
@@ -2,4 +2,5 @@
 uv = "latest"
 shellcheck = "latest"
 java = "corretto-17"
+maven = "latest"
 node = "22"


### PR DESCRIPTION
This PR adds a missing tool to the `.mise.toml` file to help local development.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
