### PR TITLE
Run Hibernate sample tests with both Maven and Gradle

### DIFF
--- a/.github/workflows/java-hibernate-ci.yml
+++ b/.github/workflows/java-hibernate-ci.yml
@@ -9,8 +9,8 @@ on:
     branches: [main]
 
 jobs:
-  build:
-    name: Build and Unit Test
+  build-dialect:
+    name: Build Dialect
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
@@ -21,15 +21,72 @@ jobs:
           java-version: "17"
           distribution: "corretto"
 
-      - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@v5
-
       - name: Build dialect and run unit tests
         working-directory: java/hibernate/dialect
         run: ./gradlew build
 
+      - name: Upload dialect JAR
+        uses: actions/upload-artifact@v4
+        with:
+          name: dialect-jar
+          path: java/hibernate/dialect/build/libs/aurora-dsql-hibernate-dialect-*[0-9].jar
+
+  build-sample:
+    name: Build Sample (${{ matrix.build-tool }})
+    needs: build-dialect
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        build-tool: [maven, gradle]
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v5
+        with:
+          java-version: "17"
+          distribution: "corretto"
+          cache: ${{ matrix.build-tool }}
+
+      - name: Build sample app (Maven)
+        if: matrix.build-tool == 'maven'
+        working-directory: java/hibernate/examples/pet-clinic-app
+        run: ./mvnw verify -DskipTests
+
+      - name: Build sample app (Gradle)
+        if: matrix.build-tool == 'gradle'
+        working-directory: java/hibernate/examples/pet-clinic-app
+        run: ./gradlew build -x test
+
+  test-sample-h2:
+    name: Test Sample (H2 + ${{ matrix.build-tool }})
+    needs: build-sample
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        build-tool: [maven, gradle]
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v5
+        with:
+          java-version: "17"
+          distribution: "corretto"
+          cache: ${{ matrix.build-tool }}
+
+      - name: Test sample app (Maven)
+        if: matrix.build-tool == 'maven'
+        working-directory: java/hibernate/examples/pet-clinic-app
+        run: ./mvnw test -Dspring.profiles.active=h2
+
+      - name: Test sample app (Gradle)
+        if: matrix.build-tool == 'gradle'
+        working-directory: java/hibernate/examples/pet-clinic-app
+        run: ./gradlew test -Dspring.profiles.active=h2
+
   create-cluster:
-    needs: build
+    needs: build-dialect
     uses: ./.github/workflows/dsql-cluster-create.yml
     with:
       workflow_name: hibernate-dialect
@@ -38,12 +95,12 @@ jobs:
     permissions:
       id-token: write # required by aws-actions/configure-aws-credentials
 
-  integration-test:
+  test-dialect:
+    name: Test Dialect (Integration)
     needs: create-cluster
     runs-on: ubuntu-latest
     permissions:
       id-token: write # required by aws-actions/configure-aws-credentials
-
     steps:
       - uses: actions/checkout@v6
 
@@ -52,10 +109,6 @@ jobs:
         with:
           java-version: "17"
           distribution: "corretto"
-          cache: maven
-
-      - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@v5
 
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v6
@@ -63,42 +116,80 @@ jobs:
           role-to-assume: ${{ secrets.IAM_ROLE }}
           aws-region: ${{ needs.create-cluster.outputs.region }}
 
-      - name: Build dialect with integration tests
+      - name: Run dialect integration tests
         working-directory: java/hibernate/dialect
         env:
           CLUSTER_ENDPOINT: ${{ needs.create-cluster.outputs.cluster-endpoint }}
           REGION: ${{ needs.create-cluster.outputs.region }}
           RUN_INTEGRATION: "TRUE"
+        run: ./gradlew build
+
+  test-sample-dsql:
+    name: Test Sample (DSQL + ${{ matrix.build-tool }})
+    needs: [build-sample, create-cluster, test-dialect]
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write # required by aws-actions/configure-aws-credentials
+    strategy:
+      fail-fast: false
+      max-parallel: 1
+      matrix:
+        build-tool: [maven, gradle]
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v5
+        with:
+          java-version: "17"
+          distribution: "corretto"
+          cache: ${{ matrix.build-tool }}
+
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v5
+        with:
+          role-to-assume: ${{ secrets.IAM_ROLE }}
+          aws-region: ${{ needs.create-cluster.outputs.region }}
+
+      - name: Download dialect JAR
+        uses: actions/download-artifact@v4
+        with:
+          name: dialect-jar
+          path: java/hibernate/examples/pet-clinic-app/lib
+
+      - name: Install dialect JAR to local Maven repo
+        if: matrix.build-tool == 'maven'
+        working-directory: java/hibernate/examples/pet-clinic-app/lib
         run: |
-          ./gradlew build -i
+          JAR_FILE="$(echo aurora-dsql-hibernate-dialect-*.jar)"
+          VERSION="${JAR_FILE//aurora-dsql-hibernate-dialect-/}"
+          VERSION="${VERSION//.jar/}"
           mvn install:install-file \
-            -Dfile=build/libs/aurora-dsql-hibernate-dialect-1.0.1.jar \
+            -Dfile="$JAR_FILE" \
             -DgroupId=software.amazon.dsql \
             -DartifactId=aurora-dsql-hibernate-dialect \
-            -Dversion=1.0.0 \
+            -Dversion="$VERSION" \
             -Dpackaging=jar
 
-      - name: Build sample application
-        working-directory: java/hibernate/examples/pet-clinic-app
-        run: |
-          mvn validate
-          mvn initialize
-          mvn clean compile
-
-      - name: Test with H2
-        working-directory: java/hibernate/examples/pet-clinic-app
-        run: mvn test -Dspring.profiles.active=h2
-
-      - name: Test with DSQL
+      - name: Build and test sample app (Maven)
+        if: matrix.build-tool == 'maven'
         working-directory: java/hibernate/examples/pet-clinic-app
         env:
           CLUSTER_ENDPOINT: ${{ needs.create-cluster.outputs.cluster-endpoint }}
           CLUSTER_USER: admin
-        run: mvn test -Dspring.profiles.active=dsql
+        run: ./mvnw test -Dspring.profiles.active=dsql
+
+      - name: Build and test sample app (Gradle)
+        if: matrix.build-tool == 'gradle'
+        working-directory: java/hibernate/examples/pet-clinic-app
+        env:
+          CLUSTER_ENDPOINT: ${{ needs.create-cluster.outputs.cluster-endpoint }}
+          CLUSTER_USER: admin
+        run: ./gradlew test -Dspring.profiles.active=dsql
 
   delete-cluster:
     if: always() && needs.create-cluster.result == 'success'
-    needs: [create-cluster, integration-test]
+    needs: [create-cluster, test-dialect, test-sample-dsql]
     uses: ./.github/workflows/dsql-cluster-delete.yml
     with:
       cluster-id: ${{ needs.create-cluster.outputs.cluster-id }}

--- a/java/hibernate/examples/pet-clinic-app/build.gradle
+++ b/java/hibernate/examples/pet-clinic-app/build.gradle
@@ -1,18 +1,11 @@
 plugins {
   id 'java'
-  id 'org.springframework.boot' version '4.0.2'
+  id 'org.springframework.boot' version '3.3.4'
   id 'io.spring.dependency-management' version '1.1.7'
-  id 'org.graalvm.buildtools.native' version '0.11.4'
-  id 'org.cyclonedx.bom' version '3.1.0'
-  id 'io.spring.javaformat' version '0.0.47'
-  id "io.spring.nohttp" version "0.0.11"
+  id 'org.graalvm.buildtools.native' version '0.10.3'
 }
 
 apply plugin: 'java'
-apply plugin: 'checkstyle'
-apply plugin: 'io.spring.javaformat'
-
-gradle.startParameter.excludedTaskNames += [ "checkFormatAot", "checkFormatAotTest" ]
 
 group = 'org.springframework.samples'
 version = '3.3.0'
@@ -25,14 +18,13 @@ repositories {
   mavenCentral()
 }
 
-ext.checkstyleVersion = "10.18.1"
-ext.springJavaformatCheckstyleVersion = "0.0.43"
 ext.webjarsFontawesomeVersion = "4.7.0"
 ext.webjarsBootstrapVersion = "5.3.8"
+ext.hibernateVersion = "6.6.4.Final"
 
 dependencies {
   implementation 'org.springframework.boot:spring-boot-starter-cache'
-  implementation 'org.hibernate:hibernate-core:6.6.42.Final'
+  implementation "org.hibernate:hibernate-core:${hibernateVersion}"
   implementation('org.springframework.boot:spring-boot-starter-data-jpa') {
         exclude group: 'org.hibernate', module: 'hibernate-core'
   }
@@ -59,35 +51,23 @@ dependencies {
   // AWS SDK deps
   implementation 'software.amazon.awssdk:dsql:2.41.22'
   implementation 'software.amazon.dsql:aurora-dsql-hibernate-dialect:1.0.1'
+  implementation 'software.amazon.dsql:aurora-dsql-jdbc-connector:1.3.0'
 
   implementation fileTree(dir: 'lib', includes: ['*.jar'])
 }
 
-//tasks.named('test') {
-//  useJUnitPlatform()
-//}
-
-checkstyle {
-  configDirectory = project.file('src/checkstyle')
-  configFile = file('src/checkstyle/nohttp-checkstyle.xml')
+tasks.named('test') {
+  useJUnitPlatform()
+  
+  def profile = System.getProperty('spring.profiles.active') ?: System.getenv('SPRING_PROFILES_ACTIVE') ?: ''
+  
+  doFirst {
+    if (!profile) {
+      throw new GradleException("spring.profiles.active must be set. Use -Dspring.profiles.active=h2 or =dsql")
+    }
+  }
+  
+  systemProperty 'spring.profiles.active', profile
+  environment 'CLUSTER_ENDPOINT', System.getenv('CLUSTER_ENDPOINT') ?: ''
+  environment 'CLUSTER_USER', System.getenv('CLUSTER_USER') ?: ''
 }
-
-checkstyleNohttp {
-  configDirectory = project.file('src/checkstyle')
-  configFile = file('src/checkstyle/nohttp-checkstyle.xml')
-}
-
-tasks.named("formatMain").configure { dependsOn("checkstyleMain") }
-tasks.named("formatMain").configure { dependsOn("checkstyleNohttp") }
-
-tasks.named("formatTest").configure { dependsOn("checkstyleTest") }
-tasks.named("formatTest").configure { dependsOn("checkstyleNohttp") }
-
-checkstyleAot.enabled = false
-checkstyleAotTest.enabled = false
-
-checkFormatAot.enabled = false
-checkFormatAotTest.enabled = false
-
-formatAot.enabled = false
-formatAotTest.enabled = false

--- a/java/hibernate/examples/pet-clinic-app/pom.xml
+++ b/java/hibernate/examples/pet-clinic-app/pom.xml
@@ -289,12 +289,6 @@
           <failOnUnableToExtractRepoInfo>false</failOnUnableToExtractRepoInfo>
         </configuration>
       </plugin>
-      <!-- Spring Boot Actuator displays sbom-related information if a CycloneDX SBOM file is
-      present at the classpath -->
-      <plugin>
-        <groupId>org.cyclonedx</groupId>
-        <artifactId>cyclonedx-maven-plugin</artifactId>
-      </plugin>
     </plugins>
   </build>
 

--- a/java/hibernate/examples/pet-clinic-app/src/test/resources/application-dsql.properties
+++ b/java/hibernate/examples/pet-clinic-app/src/test/resources/application-dsql.properties
@@ -2,6 +2,7 @@ spring.datasource.url=jdbc:aws-dsql:postgresql://${CLUSTER_ENDPOINT}/postgres
 spring.datasource.username=${CLUSTER_USER}
 spring.datasource.driver-class-name=software.amazon.dsql.jdbc.DSQLConnector
 
+spring.jpa.database-platform=software.amazon.dsql.hibernate.dialect.AuroraDSQLDialect
 spring.jpa.hibernate.ddl-auto=create-drop
 spring.sql.init.mode=always
 spring.sql.init.schema-locations=

--- a/java/hibernate/examples/pet-clinic-app/src/test/resources/application-h2.properties
+++ b/java/hibernate/examples/pet-clinic-app/src/test/resources/application-h2.properties
@@ -5,6 +5,7 @@ spring.datasource.password=password
 
 spring.h2.console.enabled=true
 spring.jpa.defer-datasource-initialization=true
+spring.jpa.database-platform=org.hibernate.dialect.H2Dialect
 
 spring.sql.init.schema-locations=classpath*:db/h2/schema.sql
 spring.sql.init.data-locations=classpath*:db/h2/data.sql

--- a/java/hibernate/examples/pet-clinic-app/src/test/resources/application.properties
+++ b/java/hibernate/examples/pet-clinic-app/src/test/resources/application.properties
@@ -1,4 +1,3 @@
-spring.jpa.database-platform=software.amazon.dsql.hibernate.dialect.AuroraDSQLDialect
 spring.jpa.hibernate.ddl-auto=none
 spring.jpa.show-sql=true
 spring.sql.init.mode=always


### PR DESCRIPTION
Previously, the Hibernate CI workflow only tested the `pet-clinic` sample with Maven. The sample's `build.gradle` existed but had a number of problems which weren't being caught by CI, leaving it in a broken state. Several Dependabot changes worsened this, as the `ci-gate` job wasn't preventing these failing dependency upgrades from being merged for Gradle.

I have fixed the following in the Gradle configuration:
- Downgraded `org.springframework.boot` to a compatible version
- Added a check for `spring.profiles.active` to prevent accidentally running against H2 instead of DSQL
- Removed unused `checkstyle` dependency/configuration (conflicts with `prettier` which is defined in pre-commit hooks)
- Removed unused `org.cyclonedx.bom` since it only impacts production applications which already have an SBOM
- Enabled tests

I also changed the test configuration so that H2 uses its own dialect rather than the DSQL one, as this is likely how multi-DB apps will be configured in practice, and it makes more sense.

The workflow file has been updated to test combinations of H2/DSQL with Maven/Gradle, so all cases should be covered by CI. This should help prevent faulty configuration from being merged in the future.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
