### PR TITLE
Synchronize ruff rules between Python projects

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,13 +4,13 @@ repos:
     hooks:
       - id: ruff-sqlalchemy
         name: ruff (sqlalchemy)
-        entry: uv run --project python/sqlalchemy ruff check --fix
+        entry: uv run --project python/sqlalchemy ruff check --fix python/sqlalchemy
         language: system
         files: ^python/sqlalchemy/.*\.py$
         pass_filenames: false
       - id: ruff-format-sqlalchemy
         name: ruff format (sqlalchemy)
-        entry: uv run --project python/sqlalchemy ruff format
+        entry: uv run --project python/sqlalchemy ruff format python/sqlalchemy
         language: system
         files: ^python/sqlalchemy/.*\.py$
         pass_filenames: false
@@ -23,13 +23,13 @@ repos:
 
       - id: ruff-tortoise
         name: ruff (tortoise-orm)
-        entry: uv run --project python/tortoise-orm ruff check --fix
+        entry: uv run --project python/tortoise-orm ruff check --fix python/tortoise-orm
         language: system
         files: ^python/tortoise-orm/.*\.py$
         pass_filenames: false
       - id: ruff-format-tortoise
         name: ruff format (tortoise-orm)
-        entry: uv run --project python/tortoise-orm ruff format
+        entry: uv run --project python/tortoise-orm ruff format python/tortoise-orm
         language: system
         files: ^python/tortoise-orm/.*\.py$
         pass_filenames: false
@@ -42,13 +42,13 @@ repos:
 
       - id: ruff-django
         name: ruff (django)
-        entry: uv run --project python/django ruff check --fix
+        entry: uv run --project python/django ruff check --fix python/django
         language: system
         files: ^python/django/.*\.py$
         pass_filenames: false
       - id: ruff-format-django
         name: ruff format (django)
-        entry: uv run --project python/django ruff format
+        entry: uv run --project python/django ruff format python/django
         language: system
         files: ^python/django/.*\.py$
         pass_filenames: false

--- a/python/django/docs/source/conf.py
+++ b/python/django/docs/source/conf.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python3
-# -*- coding: utf-8 -*-
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 

--- a/python/django/examples/pet-clinic-app/project/pet_clinic/views.py
+++ b/python/django/examples/pet-clinic-app/project/pet_clinic/views.py
@@ -29,7 +29,7 @@ def with_retries(retries=3, failed_response=HttpResponse(status=500), initial_wa
         def retry_fn(*args, **kwargs):
             delay = initial_wait
             for i in range(retries):
-                print(("attempt: %s/%s") % (i + 1, retries))
+                print(f"attempt: {i + 1}/{retries}")
                 try:
                     return view(*args, **kwargs)
                 # TODO: check error code?
@@ -64,7 +64,7 @@ class OwnerView(View):
         try:
             owner = Owner.objects.get(id=id) if id is not None else None
         except Exception:
-            return HttpResponseBadRequest(("error: check if owner with id `%s` exists") % (html.escape(str(id))))
+            return HttpResponseBadRequest(f"error: check if owner with id `{html.escape(str(id))}` exists")
 
         name = data.get("name", owner.name if owner else None)
         # Either the name or id must be provided.
@@ -76,11 +76,11 @@ class OwnerView(View):
 
         if owner is None:
             # Owner _not_ present, creating new one
-            print(("owner: %s is not present; adding") % (name))
+            print(f"owner: {name} is not present; adding")
             owner = Owner(name=name, telephone=telephone, city=city)
         else:
             # Owner present, update existing
-            print(("owner: %s is present; updating") % (name))
+            print(f"owner: {name} is present; updating")
             owner.name = name
             owner.telephone = telephone
             owner.city = city
@@ -116,7 +116,7 @@ class PetView(View):
         try:
             pet = Pet.objects.get(id=id) if id is not None else None
         except Exception:
-            return HttpResponseBadRequest(("error: check if pet with id `%s` exists") % (html.escape(str(id))))
+            return HttpResponseBadRequest(f"error: check if pet with id `{html.escape(str(id))}` exists")
 
         name = data.get("name", pet.name if pet else None)
         # Either the name or id must be provided.
@@ -128,15 +128,15 @@ class PetView(View):
         try:
             owner = Owner.objects.get(id=owner_id) if owner_id else None
         except Exception:
-            return HttpResponseBadRequest(("error: check if owner with id `%s` exists") % (html.escape(str(owner_id))))
+            return HttpResponseBadRequest(f"error: check if owner with id `{html.escape(str(owner_id))}` exists")
 
         if pet is None:
             # Pet _not_ present, creating new one
-            print(("pet name: %s is not present; adding") % (name))
+            print(f"pet name: {name} is not present; adding")
             pet = Pet(name=name, birth_date=birth_date, owner=owner)
         else:
             # Pet present, update existing
-            print(("pet name: %s is present; updating") % (name))
+            print(f"pet name: {name} is present; updating")
             pet.name = name
             pet.birth_date = birth_date
             pet.owner = owner
@@ -171,7 +171,7 @@ class VetView(View):
         try:
             vet = Vet.objects.get(id=id) if id is not None else None
         except Exception:
-            return HttpResponseBadRequest(("error: check if vet with id `%s` exists") % (html.escape(str(id))))
+            return HttpResponseBadRequest(f"error: check if vet with id `{html.escape(str(id))}` exists")
 
         name = data.get("name", vet.name if vet else None)
 
@@ -183,7 +183,7 @@ class VetView(View):
         try:
             owner = Owner.objects.get(id=owner_id) if owner_id else None
         except Exception:
-            return HttpResponseBadRequest(("error: check if owner with id `%s` exists") % (html.escape(str(id))))
+            return HttpResponseBadRequest(f"error: check if owner with id `{html.escape(str(id))}` exists")
 
         specialties_list = data.get("specialties", vet.specialties if vet and vet.specialties else [])
         specialties = []
@@ -191,14 +191,14 @@ class VetView(View):
             try:
                 specialties_obj = Specialty.objects.get(name=specialty)
             except Exception:
-                return HttpResponseBadRequest(("error: check if specialty `%s` exists") % (html.escape(str(specialty))))
+                return HttpResponseBadRequest(f"error: check if specialty `{html.escape(str(specialty))}` exists")
             specialties.append(specialties_obj)
 
         if vet is None:
-            print(("vet name: %s, not present, adding") % (name))
+            print(f"vet name: {name}, not present, adding")
             vet = Vet(name=name, owner_id=owner_id)
         else:
-            print(("vet name: %s, present, updating") % (name))
+            print(f"vet name: {name}, present, updating")
             vet.name = name
             vet.owner = owner
 

--- a/python/django/pyproject.toml
+++ b/python/django/pyproject.toml
@@ -90,8 +90,15 @@ exclude = [
 ]
 
 [tool.ruff.lint]
-select = ["E", "F", "W", "I"]
-ignore = []
+extend-select = [
+    "E",      # https://docs.astral.sh/ruff/rules/#error-e
+    "F",      # https://docs.astral.sh/ruff/rules/#pyflakes-f
+    "FA",     # https://docs.astral.sh/ruff/rules/#flake8-future-annotations-fa
+    "I",      # https://docs.astral.sh/ruff/rules/#isort-i
+    "RUF100", # https://docs.astral.sh/ruff/rules/#ruff-specific-rules-ruf
+    "UP",     # https://docs.astral.sh/ruff/rules/#pyupgrade-up
+    "W",      # https://docs.astral.sh/ruff/rules/#warning-w
+]
 
 [tool.ruff.format]
 quote-style = "double"


### PR DESCRIPTION
Pr #153 is failing because it is incorrectly using the stricter SQLAlchemy `ruff` rules to check Django.

I have fixed this by:
- Filtering where the checks run to make sure each check only verifies what it is supposed to
- Synchronizing the Django rules to match SQLAlchemy and Tortoise ORM (which already use the same rules) so all 3 projects check the same things

As part of the second change, a few things were automatically fixed to align with the stricter rules.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
