### PR TITLE
Update links to point to new mono-repos

### DIFF
--- a/node/prisma/README.md
+++ b/node/prisma/README.md
@@ -172,7 +172,7 @@ See [examples/veterinary-app/](examples/veterinary-app/) for a complete working 
 
 - [Amazon Aurora DSQL Documentation](https://docs.aws.amazon.com/aurora-dsql/latest/userguide/what-is-aurora-dsql.html)
 - [Unsupported PostgreSQL Features in DSQL](https://docs.aws.amazon.com/aurora-dsql/latest/userguide/working-with-postgresql-compatibility-unsupported-features.html)
-- [Aurora DSQL Node.js Connector](https://github.com/awslabs/aurora-dsql-connectors/tree/main/node/node-postgres/)
+- [Aurora DSQL Connector for node-postgres](https://github.com/awslabs/aurora-dsql-connectors/tree/main/node/node-postgres/)
 - [Prisma Documentation](https://www.prisma.io/docs)
 - [Prisma Relation Mode](https://www.prisma.io/docs/orm/prisma-schema/data-model/relations/relation-mode)
 

--- a/node/prisma/README.md
+++ b/node/prisma/README.md
@@ -172,7 +172,7 @@ See [examples/veterinary-app/](examples/veterinary-app/) for a complete working 
 
 - [Amazon Aurora DSQL Documentation](https://docs.aws.amazon.com/aurora-dsql/latest/userguide/what-is-aurora-dsql.html)
 - [Unsupported PostgreSQL Features in DSQL](https://docs.aws.amazon.com/aurora-dsql/latest/userguide/working-with-postgresql-compatibility-unsupported-features.html)
-- [Aurora DSQL Node.js Connector](https://github.com/awslabs/aurora-dsql-nodejs-connector)
+- [Aurora DSQL Node.js Connector](https://github.com/awslabs/aurora-dsql-connectors/tree/main/node/node-postgres/)
 - [Prisma Documentation](https://www.prisma.io/docs)
 - [Prisma Relation Mode](https://www.prisma.io/docs/orm/prisma-schema/data-model/relations/relation-mode)
 

--- a/python/django/setup.py
+++ b/python/django/setup.py
@@ -6,7 +6,8 @@ import re
 from setuptools import setup
 from setuptools_scm import get_version
 
-GITHUB_URL = "https://github.com/awslabs/aurora-dsql-django"
+GITHUB_URL = "https://github.com/awslabs/aurora-dsql-orms"
+SUBDIR = "python/django"
 version = get_version()
 
 # Use default branch for dev versions, tag for releases.
@@ -23,7 +24,7 @@ def convert_relative_link(match):
     old_url = match.group(2)
     if old_url.startswith("./") or old_url.startswith("../"):
         raise ValueError(f"Relative links starting with './' or '../' are not allowed: {old_url}")
-    new_url = f"{GITHUB_URL}/blob/{ref}/{old_url}"
+    new_url = f"{GITHUB_URL}/blob/{ref}/{SUBDIR}/{old_url}"
     print(f"Converting: {old_url} -> {new_url}")
     return f"[{link_text}]({new_url})"
 

--- a/python/sqlalchemy/examples/pet-clinic-app/README.md
+++ b/python/sqlalchemy/examples/pet-clinic-app/README.md
@@ -264,7 +264,7 @@ class Vet(Base):
 ## Additional resources
 
 - [Amazon Aurora DSQL Documentation](https://docs.aws.amazon.com/aurora-dsql/latest/userguide/what-is-aurora-dsql.html)
-- [Aurora DSQL Python Connector](https://github.com/awslabs/aurora-dsql-python-connector)
+- [Aurora DSQL Python Connector](https://github.com/awslabs/aurora-dsql-connectors/tree/main/python/connector/)
 - [SQLAlchemy Documentation](https://docs.sqlalchemy.org/en/20/)
 - [Psycopg Documentation](https://www.psycopg.org/docs/)
 

--- a/python/tortoise-orm/README.md
+++ b/python/tortoise-orm/README.md
@@ -50,7 +50,7 @@ TORTOISE_ORM = {
 }
 ```
 
-The adapter accepts all parameters supported by the underlying [asyncpg](https://magicstack.github.io/asyncpg/current/api/index.html) or [psycopg](https://www.psycopg.org/psycopg3/docs/) driver, as well as the [Aurora DSQL Connector for Python](https://github.com/awslabs/aurora-dsql-python-connector).
+The adapter accepts all parameters supported by the underlying [asyncpg](https://magicstack.github.io/asyncpg/current/api/index.html) or [psycopg](https://www.psycopg.org/psycopg3/docs/) driver, as well as the [Aurora DSQL Connector for Python](https://github.com/awslabs/aurora-dsql-connectors/tree/main/python/connector/).
 
 Or use a connection URL (requires registering the backend first):
 


### PR DESCRIPTION
## Summary

Connector packages have been migrated from individual repos to a consolidated mono-repo. This PR updates documentation links and the django setup.py to point to the new locations.

### Link Mappings

| Old Repo | New Location |
|----------|--------------|
| `aurora-dsql-nodejs-connector` | `aurora-dsql-connectors/node/` |
| `aurora-dsql-python-connector` | `aurora-dsql-connectors/python/connector/` |

### Files Changed

| File | Change Type |
|------|-------------|
| `node/prisma/README.md` | URL update |
| `python/tortoise-orm/README.md` | URL update |
| `python/sqlalchemy/examples/pet-clinic-app/README.md` | URL update |
| `python/django/setup.py` | URL + code fix |

### setup.py Fix

The setup.py uses `GITHUB_URL` to construct blob URLs for PyPI readme links. Updated to handle mono-repo subdirectory structure:

```python
# Before
GITHUB_URL = "https://github.com/awslabs/aurora-dsql-django"
new_url = f"{GITHUB_URL}/blob/{ref}/{old_url}"

# After
GITHUB_URL = "https://github.com/awslabs/aurora-dsql-orms"
SUBDIR = "python/django"
new_url = f"{GITHUB_URL}/blob/{ref}/{SUBDIR}/{old_url}"
```

## Test plan

- [x] All new URLs verified accessible (HTTP 200)
- [x] setup.py URL generation tested - produces correct paths
- [x] No old deprecated repo URLs remain (except historical CHANGELOGs)