### PR TITLE
Fix hono and fast-xml-parser security vulnerabilities, improve Dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -57,12 +57,12 @@ updates:
       # Checkstyle 13+ requires Java 21, but this project targets Java 17
       - dependency-name: "com.puppycrawl.tools:checkstyle"
         versions: [">=13"]
+  # Use 'directories' (plural) so the connector and its example are
+  # updated in the same PR, keeping lockfiles consistent.
   - package-ecosystem: "npm"
-    directory: "/node/prisma"
-    schedule:
-      interval: "daily"
-  - package-ecosystem: "npm"
-    directory: "/node/prisma/examples/veterinary-app"
+    directories:
+      - "/node/prisma"
+      - "/node/prisma/examples/veterinary-app"
     schedule:
       interval: "daily"
   - package-ecosystem: "github-actions"

--- a/node/prisma/examples/veterinary-app/package-lock.json
+++ b/node/prisma/examples/veterinary-app/package-lock.json
@@ -5428,9 +5428,9 @@
       }
     },
     "node_modules/hono": {
-      "version": "4.11.7",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.11.7.tgz",
-      "integrity": "sha512-l7qMiNee7t82bH3SeyUCt9UF15EVmaBvsppY2zQtrbIhl/yzBTny+YUxsVjSjQ6gaqaeVtZmGocom8TzBlA4Yw==",
+      "version": "4.12.3",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.3.tgz",
+      "integrity": "sha512-SFsVSjp8sj5UumXOOFlkZOG6XS9SJDKw0TbwFeV+AJ8xlST8kxK5Z/5EYa111UY8732lK2S/xB653ceuaoGwpg==",
       "devOptional": true,
       "license": "MIT",
       "engines": {

--- a/node/prisma/examples/veterinary-app/package.json
+++ b/node/prisma/examples/veterinary-app/package.json
@@ -39,14 +39,14 @@
   },
   "overrides": {
     "lodash": "^4.17.23",
-    "hono": "^4.11.7",
-    "fast-xml-parser": "^5.3.4"
+    "hono": "^4.11.10",
+    "fast-xml-parser": "^5.4.1"
   },
   "comments": {
     "overrides": {
       "lodash": "CVE-2025-13465 - Remove when prisma updates to lodash >=4.17.23",
-      "hono": "CVE-2026-24472 - Remove when prisma updates to hono >=4.11.7",
-      "fast-xml-parser": "CVE-2026-25128 - Remove when @aws-sdk/xml-builder updates to fast-xml-parser >=5.3.4"
+      "hono": "CVE-2026-24472 - Remove when prisma updates to hono >=4.11.10",
+      "fast-xml-parser": "Stack overflow in XMLBuilder - Remove when @aws-sdk/xml-builder updates to fast-xml-parser >=5.3.8"
     }
   }
 }

--- a/node/prisma/package-lock.json
+++ b/node/prisma/package-lock.json
@@ -4542,10 +4542,23 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/fast-xml-builder": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.0.0.tgz",
+      "integrity": "sha512-fpZuDogrAgnyt9oDDz+5DBz0zgPdPZz6D4IR7iESxRXElrlGTRkHJ9eEt+SACRJwT0FNFrt71DFQIUFBJfX/uQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT"
+    },
     "node_modules/fast-xml-parser": {
-      "version": "5.3.6",
-      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.3.6.tgz",
-      "integrity": "sha512-QNI3sAvSvaOiaMl8FYU4trnEzCwiRr8XMWgAHzlrWpTSj+QaCSvOf1h82OEP1s4hiAXhnbXSyFWCf4ldZzZRVA==",
+      "version": "5.4.1",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.4.1.tgz",
+      "integrity": "sha512-BQ30U1mKkvXQXXkAGcuyUA/GA26oEB7NzOtsxCDtyu62sjGw5QraKFhx2Em3WQNjPw9PG6MQ9yuIIgkSDfGu5A==",
       "dev": true,
       "funding": [
         {
@@ -4555,6 +4568,7 @@
       ],
       "license": "MIT",
       "dependencies": {
+        "fast-xml-builder": "^1.0.0",
         "strnum": "^2.1.2"
       },
       "bin": {
@@ -4810,9 +4824,9 @@
       }
     },
     "node_modules/hono": {
-      "version": "4.11.7",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.11.7.tgz",
-      "integrity": "sha512-l7qMiNee7t82bH3SeyUCt9UF15EVmaBvsppY2zQtrbIhl/yzBTny+YUxsVjSjQ6gaqaeVtZmGocom8TzBlA4Yw==",
+      "version": "4.12.3",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.3.tgz",
+      "integrity": "sha512-SFsVSjp8sj5UumXOOFlkZOG6XS9SJDKw0TbwFeV+AJ8xlST8kxK5Z/5EYa111UY8732lK2S/xB653ceuaoGwpg==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/node/prisma/package.json
+++ b/node/prisma/package.json
@@ -54,12 +54,14 @@
   },
   "overrides": {
     "lodash": "^4.17.23",
-    "hono": "^4.11.7"
+    "hono": "^4.11.10",
+    "fast-xml-parser": "^5.4.1"
   },
   "comments": {
     "overrides": {
       "lodash": "CVE-2025-13465 - Remove when prisma updates to lodash >=4.17.23",
-      "hono": "CVE-2026-24472 - Remove when prisma updates to hono >=4.11.7"
+      "hono": "CVE-2026-24472 - Remove when prisma updates to hono >=4.11.10",
+      "fast-xml-parser": "Stack overflow in XMLBuilder - Remove when @aws-sdk/xml-builder updates to fast-xml-parser >=5.3.8"
     }
   }
 }


### PR DESCRIPTION
## Summary

Resolves all 3 open Dependabot security alerts and fixes a systemic Dependabot config issue.

## Security Alerts Fixed

| Severity | Alert | Package | Location | Fix |
|----------|-------|---------|----------|-----|
| LOW | #32 | fast-xml-parser < 5.3.8 | node/prisma | Added override ^5.4.1 |
| LOW | #19 | hono < 4.11.10 | node/prisma | Bumped override ^4.11.7 → ^4.11.10 |
| LOW | #18 | hono < 4.11.10 | node/prisma/examples/veterinary-app | Bumped override ^4.11.7 → ^4.11.10 |

The existing overrides had version ranges that were too low to cover the required fix versions.

## Dependabot Config Fix

Changed `node/prisma` and `node/prisma/examples/veterinary-app` from separate `directory` entries to a single entry using `directories` (plural). This ensures both lockfiles are updated in the same PR, keeping dependencies consistent between the library and its example.

## Test plan

- [x] `npm audit` reports 0 vulnerabilities in both directories
- [ ] CI passes