### PR TITLE
Tortoise 1.0 fixes and don't require both asyncpg + psycopg to be installed.

### DIFF
--- a/python/tortoise-orm/aurora_dsql_tortoise/__init__.py
+++ b/python/tortoise-orm/aurora_dsql_tortoise/__init__.py
@@ -4,8 +4,18 @@
 __all__ = ["register_backends", "register_asyncpg", "register_psycopg"]
 
 from aurora_dsql_tortoise._version import __version__ as __version__
-from aurora_dsql_tortoise.asyncpg import register_backend as register_asyncpg
-from aurora_dsql_tortoise.psycopg import register_backend as register_psycopg
+
+
+def register_asyncpg():
+    # Defer import to avoid depending on asyncpg in __init__
+    from aurora_dsql_tortoise.asyncpg import register_backend as _register_asyncpg
+    _register_asyncpg()
+
+
+def register_psycopg():
+    # Defer import to avoid depending on psycopg in __init__
+    from aurora_dsql_tortoise.psycopg import register_backend as _register_psycopg
+    _register_psycopg()
 
 
 def register_backends():

--- a/python/tortoise-orm/aurora_dsql_tortoise/__init__.py
+++ b/python/tortoise-orm/aurora_dsql_tortoise/__init__.py
@@ -9,12 +9,14 @@ from aurora_dsql_tortoise._version import __version__ as __version__
 def register_asyncpg():
     # Defer import to avoid depending on asyncpg in __init__
     from aurora_dsql_tortoise.asyncpg import register_backend as _register_asyncpg
+
     _register_asyncpg()
 
 
 def register_psycopg():
     # Defer import to avoid depending on psycopg in __init__
     from aurora_dsql_tortoise.psycopg import register_backend as _register_psycopg
+
     _register_psycopg()
 
 

--- a/python/tortoise-orm/aurora_dsql_tortoise/common/schema_generator.py
+++ b/python/tortoise-orm/aurora_dsql_tortoise/common/schema_generator.py
@@ -21,10 +21,19 @@ from aurora_dsql_tortoise.common.fields import DEFAULT_SEQUENCE_CACHE_SIZE, _get
 
 class AuroraDSQLSchemaGeneratorMixin(_Base):
     """Adapts schema generation for DSQL."""
+    __table_name_clause = (
+        '{table_name}'  # tortoise>=1.0.0
+        if '"{table_name}"' not in BasePostgresSchemaGenerator.INDEX_CREATE_TEMPLATE
+        else '"{table_name}"'  # tortoise<1.0.0
+    )
 
     client: BasePostgresClient
+
     INDEX_CREATE_TEMPLATE = (
-        'CREATE INDEX ASYNC {exists}"{index_name}" ON "{table_name}" {index_type}({fields}){extra};'
+        'CREATE INDEX ASYNC {exists}"{index_name}" ON {table_name} {index_type}({fields}){extra};'.replace(
+            '{table_name}',
+            __table_name_clause,
+        )
     )
     UNIQUE_INDEX_CREATE_TEMPLATE = INDEX_CREATE_TEMPLATE.replace("INDEX", "UNIQUE INDEX")
 

--- a/python/tortoise-orm/aurora_dsql_tortoise/common/schema_generator.py
+++ b/python/tortoise-orm/aurora_dsql_tortoise/common/schema_generator.py
@@ -21,8 +21,9 @@ from aurora_dsql_tortoise.common.fields import DEFAULT_SEQUENCE_CACHE_SIZE, _get
 
 class AuroraDSQLSchemaGeneratorMixin(_Base):
     """Adapts schema generation for DSQL."""
+
     __table_name_clause = (
-        '{table_name}'  # tortoise>=1.0.0
+        "{table_name}"  # tortoise>=1.0.0
         if '"{table_name}"' not in BasePostgresSchemaGenerator.INDEX_CREATE_TEMPLATE
         else '"{table_name}"'  # tortoise<1.0.0
     )
@@ -30,10 +31,10 @@ class AuroraDSQLSchemaGeneratorMixin(_Base):
     client: BasePostgresClient
 
     INDEX_CREATE_TEMPLATE = (
-        'CREATE INDEX ASYNC {exists}"{index_name}" ON {table_name} {index_type}({fields}){extra};'.replace(
-            '{table_name}',
-            __table_name_clause,
-        )
+        'CREATE INDEX ASYNC {exists}"{index_name}" ON {table_name} {index_type}({fields}){extra};'
+    ).replace(
+        "{table_name}",
+        __table_name_clause,
     )
     UNIQUE_INDEX_CREATE_TEMPLATE = INDEX_CREATE_TEMPLATE.replace("INDEX", "UNIQUE INDEX")
 

--- a/python/tortoise-orm/tests/unit/test_public_api.py
+++ b/python/tortoise-orm/tests/unit/test_public_api.py
@@ -2,6 +2,13 @@
 # SPDX-License-Identifier: Apache-2.0
 
 
+import importlib
+import sys
+from unittest.mock import patch
+
+import pytest
+
+
 def test_public_api():
     import aurora_dsql_tortoise
 
@@ -10,3 +17,38 @@ def test_public_api():
         "register_asyncpg",
         "register_psycopg",
     }
+
+
+BACKENDS = {
+    "asyncpg": "register_asyncpg",
+    "psycopg": "register_psycopg",
+}
+
+
+@pytest.mark.parametrize("backend", BACKENDS.keys())
+def test_import_doesnt_require_other_backend(subtests, backend):
+    """Test that importing the dsql client doesn't require unneeded dependencies from the other backend."""
+    # We run the entire import tree while pretending that psycopg isn't installed
+    other_backends = {b for b in BACKENDS.keys() if b != backend}
+    no_other_backends = {
+        k: None
+        for k in sys.modules.keys() 
+        for other in other_backends
+        if k.startswith(other)
+    }
+    evict_dsql = {k for k in sys.modules.keys() if k.startswith("aurora_dsql_tortoise")}
+
+    with patch.dict(sys.modules, no_other_backends) as mods:
+        for mod in evict_dsql:
+            mods.pop(mod, None)
+
+        with subtests.test(f"Importing root module for {backend} doesn't require {other_backends}"):
+            root = importlib.import_module("aurora_dsql_tortoise")
+            root = importlib.reload(root) # Test: No dependency at import time
+
+        with subtests.test(f"Registering {backend} backend doesn't require {other_backends}"):
+            getattr(root, BACKENDS[backend])()
+
+        with subtests.test(f"Importing {backend} engine module doesn't require {other_backends}"):
+            engine_mod = importlib.import_module(f"aurora_dsql_tortoise.{backend}")
+            engine_mod = importlib.reload(engine_mod)

--- a/python/tortoise-orm/tests/unit/test_public_api.py
+++ b/python/tortoise-orm/tests/unit/test_public_api.py
@@ -27,14 +27,11 @@ BACKENDS = {
 
 @pytest.mark.parametrize("backend", BACKENDS.keys())
 def test_import_doesnt_require_other_backend(subtests, backend):
-    """Test that importing the dsql client doesn't require unneeded dependencies from the other backend."""
+    """Verify using package doesn't require multiple backends"""
     # We run the entire import tree while pretending that psycopg isn't installed
     other_backends = {b for b in BACKENDS.keys() if b != backend}
     no_other_backends = {
-        k: None
-        for k in sys.modules.keys() 
-        for other in other_backends
-        if k.startswith(other)
+        k: None for k in sys.modules.keys() for other in other_backends if k.startswith(other)
     }
     evict_dsql = {k for k in sys.modules.keys() if k.startswith("aurora_dsql_tortoise")}
 
@@ -42,9 +39,9 @@ def test_import_doesnt_require_other_backend(subtests, backend):
         for mod in evict_dsql:
             mods.pop(mod, None)
 
-        with subtests.test(f"Importing root module for {backend} doesn't require {other_backends}"):
+        with subtests.test(f"Root module for {backend} doesn't require {other_backends}"):
             root = importlib.import_module("aurora_dsql_tortoise")
-            root = importlib.reload(root) # Test: No dependency at import time
+            root = importlib.reload(root)  # Test: No dependency at import time
 
         with subtests.test(f"Registering {backend} backend doesn't require {other_backends}"):
             getattr(root, BACKENDS[backend])()

--- a/python/tortoise-orm/tests/unit/test_schema_generator.py
+++ b/python/tortoise-orm/tests/unit/test_schema_generator.py
@@ -83,6 +83,9 @@ async def test_schema_uses_async_index_creation(initialized_models, generator_cl
     assert "CREATE INDEX ASYNC" in schema_sql, (
         f"Schema should use ASYNC index creation:\n{schema_sql}"
     )
+    assert 'ON "test_parent" (' in schema_sql, (
+        f"Schema should use the correct table name in index creation:\n{schema_sql}"
+    )
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
This PR fixes two issues preventing using the DSQL Tortoise ORM integration:

1. The module used to require having both `asyncpg` and `psycopg` installed. This is because importing the `aurora_dsql_tortoise` root module (which occurs when Tortoise uses importlib to import eg `aurora_dsql_tortoise.asyncpg`) ends up importing each submodule's register functions, which transitively imports the underlying backend module.

    I added some deferred imports and added a test so that if you are planning to use `$backend`, you can import all of the core parts of this module without them importing the other backends. The ImportError errors at least give you a nice stack trace and error description in the test.

    Truthfully, we should probably use tox to test a couple of "expected to be good" environments instead of patching the import system in a unit test. But we may add that later.

3. Tortoise1 made a bunch of changes compared to <1. One of the things they changed was the template arguments so that table_name is escaped _before_ being provided to the template. The net effect is that if you use this DSQL module with the newer Tortoise v1, this module tries doing:

    `CREATE INDEX ASYNC IF NOT EXISTS ... ON ""test_parent"" (...);`

    Note that double quoting around the table name, which is a syntax error. I did not want to drop support for tortoise<1, so I just support both heuristically in this PR. Hopefully when you guys decide to drop support for <1, you can just remove that branch.

    Another thing they changed is the inbuilt migrations mechanism. Due to them changing how the PK field SQL is calculated, this package can't inject the `BIGSERIAL => GENERATED BY DEFAULT AS IDENTITY` shim. That's one problem here. The other is that the migration table tortoise ships uses `SERIAL` anyways (not `BIGSERIAL`) so the inbuilt migration mechanism is somewhat moot anyways.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
