### PR TITLE
django: Add table recreation for unsupported ALTER TABLE operations

### DIFF
--- a/python/django/aurora_dsql_django/schema.py
+++ b/python/django/aurora_dsql_django/schema.py
@@ -13,10 +13,11 @@ adapted from Django's SQLite backend.
 
 import copy
 import logging
+import re
 import time
 
 from django.apps.registry import Apps
-from django.db import OperationalError
+from django.db import OperationalError, ProgrammingError
 from django.db.backends.base.schema import BaseDatabaseSchemaEditor
 from django.db.backends.ddl_references import Statement
 from django.db.backends.postgresql import schema
@@ -72,6 +73,13 @@ class DatabaseSchemaEditor(schema.DatabaseSchemaEditor):
             return exc.__cause__.sqlstate in ("OC000", "OC001")
         return False
 
+    @staticmethod
+    def _is_duplicate_relation_error(exc):
+        """Check whether a ProgrammingError is a duplicate relation (sqlstate 42P07)."""
+        if hasattr(exc, "__cause__") and hasattr(exc.__cause__, "sqlstate"):
+            return exc.__cause__.sqlstate == "42P07"
+        return False
+
     def execute(self, sql, params=()):
         """
         Execute SQL with automatic retry on DSQL OCC errors.
@@ -79,10 +87,32 @@ class DatabaseSchemaEditor(schema.DatabaseSchemaEditor):
         DSQL may reject operations with SerializationFailure (OC000/OC001)
         when concurrent schema changes conflict. Since can_rollback_ddl=False,
         each execute() auto-commits independently, making retries safe.
+
+        Also handles "already exists" errors on CREATE INDEX ASYNC statements.
+        DSQL creates indexes asynchronously, and an in-progress ASYNC index
+        may survive a DROP TABLE, leaving an orphaned index name. When this
+        happens, the existing index is dropped and the CREATE is retried.
         """
         for attempt in range(_OCC_MAX_RETRIES):
             try:
                 return super().execute(sql, params)
+            except ProgrammingError as e:
+                # DSQL's ASYNC index creation can leave orphaned index names
+                # that survive DROP TABLE. If a CREATE INDEX hits "already
+                # exists" (42P07), drop the stale index and retry once.
+                sql_str = str(sql)
+                if attempt == 0 and self._is_duplicate_relation_error(e) and "INDEX" in sql_str:
+                    # Extract the index name: it's the first quoted identifier
+                    # after "INDEX" (or "INDEX ASYNC") in the SQL.
+                    match = re.search(r"INDEX\s+(?:ASYNC\s+)?(?:IF\s+NOT\s+EXISTS\s+)?(\S+)", sql_str)
+                    if match:
+                        index_name = strip_quotes(match.group(1))
+                        logger.debug("Index %s already exists, dropping and retrying", index_name)
+                        self.connection.close()
+                        self.connection.ensure_connection()
+                        super().execute(f"DROP INDEX IF EXISTS {self.quote_name(index_name)}")
+                        continue
+                raise
             except OperationalError as e:
                 if not self._is_occ_error(e) or attempt == _OCC_MAX_RETRIES - 1:
                     raise

--- a/python/django/aurora_dsql_django/schema.py
+++ b/python/django/aurora_dsql_django/schema.py
@@ -29,7 +29,7 @@ logger = logging.getLogger(__name__)
 _OCC_MAX_RETRIES = 3
 _OCC_RETRY_DELAY = 1.0
 
-# DSQL has a 3000 row limit per transaction. Use a smaller batch size
+# DSQL has a ~3000 row limit per transaction. Use a smaller batch size
 # to stay well within the limit when copying data during table recreation.
 _COPY_BATCH_SIZE = 1000
 
@@ -211,11 +211,16 @@ class DatabaseSchemaEditor(schema.DatabaseSchemaEditor):
             window. For production schema changes, consider blue/green
             deployments or manual migration strategies.
         """
+        # Deleting an M2M field just drops the through table -- no recreation.
+        if delete_field:
+            if delete_field.many_to_many and delete_field.remote_field.through._meta.auto_created:
+                return self.delete_model(delete_field.remote_field.through)
+
         # Work out the new fields dict / mapping
         body = {f.name: f for f in model._meta.local_concrete_fields}
         # Since mapping might mix column names and default values,
         # its values must be already quoted.
-        mapping = {f.column: self.quote_name(f.column) for f in model._meta.local_concrete_fields if f.generated is False}
+        mapping = {f.column: self.quote_name(f.column) for f in model._meta.local_concrete_fields if not f.generated}
         # This maps field names (not columns) for things like unique_together
         rename_mapping = {}
         # If any of the new or altered fields is introducing a new PK,
@@ -243,8 +248,7 @@ class DatabaseSchemaEditor(schema.DatabaseSchemaEditor):
             ):
                 mapping[create_field.column] = self.quote_value(self.effective_default(create_field))
         # Add in any altered fields
-        for alter_field in alter_fields:
-            old_field, new_field = alter_field
+        for old_field, new_field in alter_fields:
             body.pop(old_field.name, None)
             mapping.pop(old_field.column, None)
             body[new_field.name] = new_field
@@ -258,17 +262,13 @@ class DatabaseSchemaEditor(schema.DatabaseSchemaEditor):
                     default = self.quote_value(self.effective_default(new_field))
                 else:
                     default, _ = self.db_default_sql(new_field)
-                case_sql = f"coalesce({self.quote_name(old_field.column)}, {default})"
-                mapping[new_field.column] = case_sql
+                mapping[new_field.column] = f"coalesce({self.quote_name(old_field.column)}, {default})"
             else:
                 mapping[new_field.column] = self.quote_name(old_field.column)
         # Remove any deleted fields
         if delete_field:
             del body[delete_field.name]
             mapping.pop(delete_field.column, None)
-            # Remove any implicit M2M tables
-            if delete_field.many_to_many and delete_field.remote_field.through._meta.auto_created:
-                return self.delete_model(delete_field.remote_field.through)
         # Work inside a new app registry
         apps = Apps()
 
@@ -353,9 +353,9 @@ class DatabaseSchemaEditor(schema.DatabaseSchemaEditor):
         # (from earlier operations in this schema editor session) before we
         # replace it. create_model() below will generate fresh deferred SQL
         # for the new table, and alter_db_table() will rename those references.
-        for sql in list(self.deferred_sql):
-            if isinstance(sql, Statement) and sql.references_table(original_table):
-                self.deferred_sql.remove(sql)
+        self.deferred_sql = [
+            sql for sql in self.deferred_sql if not (isinstance(sql, Statement) and sql.references_table(original_table))
+        ]
 
         # Step 1: Rename the original table to freeze it against concurrent writes.
         # Any writes to the original table name will now fail loudly.
@@ -404,16 +404,12 @@ class DatabaseSchemaEditor(schema.DatabaseSchemaEditor):
                 )
 
         # Step 4: Drop the old (frozen) table.
-        self.execute(self.sql_delete_table % {"table": self.quote_name(old_table)})
+        self.execute(self.sql_delete_table % {"table": q_old})
 
         # Step 5: Rename the new table to the original name.
         # alter_db_table also updates deferred SQL references from
         # new__<table> to the original table name.
-        self.alter_db_table(
-            new_model,
-            new_model._meta.db_table,
-            original_table,
-        )
+        self.alter_db_table(new_model, new_table, original_table)
 
         # Step 6: Run deferred SQL (indexes) on the correctly-named table.
         # Each execute() auto-commits (can_rollback_ddl = False), so each

--- a/python/django/aurora_dsql_django/schema.py
+++ b/python/django/aurora_dsql_django/schema.py
@@ -262,9 +262,7 @@ class DatabaseSchemaEditor(schema.DatabaseSchemaEditor):
         new_model = type(f"New{model._meta.object_name}", model.__bases__, body_copy)
 
         # Drop any leftover temp table from a previous failed _remake_table.
-        self.execute(
-            f"DROP TABLE IF EXISTS {self.quote_name(new_model._meta.db_table)}"
-        )
+        self.execute(f"DROP TABLE IF EXISTS {self.quote_name(new_model._meta.db_table)}")
 
         # Create a new table with the updated schema.
         self.create_model(new_model)

--- a/python/django/aurora_dsql_django/schema.py
+++ b/python/django/aurora_dsql_django/schema.py
@@ -67,18 +67,15 @@ class DatabaseSchemaEditor(schema.DatabaseSchemaEditor):
         return self
 
     @staticmethod
-    def _is_occ_error(exc):
-        """Check whether an OperationalError is a DSQL OCC conflict (OC000/OC001)."""
-        if hasattr(exc, "__cause__") and hasattr(exc.__cause__, "sqlstate"):
-            return exc.__cause__.sqlstate in ("OC000", "OC001")
-        return False
+    def _get_sqlstate(exc):
+        """Extract the PostgreSQL sqlstate from a Django database exception."""
+        cause = getattr(exc, "__cause__", None)
+        return getattr(cause, "sqlstate", None)
 
-    @staticmethod
-    def _is_duplicate_relation_error(exc):
-        """Check whether a ProgrammingError is a duplicate relation (sqlstate 42P07)."""
-        if hasattr(exc, "__cause__") and hasattr(exc.__cause__, "sqlstate"):
-            return exc.__cause__.sqlstate == "42P07"
-        return False
+    @classmethod
+    def _is_occ_error(cls, exc):
+        """Check whether an OperationalError is a DSQL OCC conflict (OC000/OC001)."""
+        return cls._get_sqlstate(exc) in ("OC000", "OC001")
 
     def execute(self, sql, params=()):
         """
@@ -101,7 +98,7 @@ class DatabaseSchemaEditor(schema.DatabaseSchemaEditor):
                 # that survive DROP TABLE. If a CREATE INDEX hits "already
                 # exists" (42P07), drop the stale index and retry once.
                 sql_str = str(sql)
-                if attempt == 0 and self._is_duplicate_relation_error(e) and "INDEX" in sql_str:
+                if attempt == 0 and self._get_sqlstate(e) == "42P07" and "INDEX" in sql_str:
                     # Extract the index name: it's the first quoted identifier
                     # after "INDEX" (or "INDEX ASYNC") in the SQL.
                     match = re.search(r"INDEX\s+(?:ASYNC\s+)?(?:IF\s+NOT\s+EXISTS\s+)?(\S+)", sql_str)
@@ -118,7 +115,7 @@ class DatabaseSchemaEditor(schema.DatabaseSchemaEditor):
                     raise
                 logger.debug(
                     "DSQL OCC error (sqlstate=%s) on attempt %d/%d, retrying in %.1fs",
-                    e.__cause__.sqlstate,
+                    self._get_sqlstate(e),
                     attempt + 1,
                     _OCC_MAX_RETRIES,
                     _OCC_RETRY_DELAY,
@@ -206,19 +203,34 @@ class DatabaseSchemaEditor(schema.DatabaseSchemaEditor):
     # deployments or manual migration strategies.
     # -------------------------------------------------------------------------
 
-    def _query_with_retry(self, sql, params=None):
-        """Execute a read query with OCC retry, returning all rows."""
+    def _occ_retry(self, fn):
+        """Run fn() with automatic retry on DSQL OCC errors (OC000/OC001)."""
         for attempt in range(_OCC_MAX_RETRIES):
             try:
-                with self.connection.cursor() as cursor:
-                    cursor.execute(sql, params)
-                    return cursor.fetchall()
+                return fn()
             except OperationalError as e:
                 if not self._is_occ_error(e) or attempt == _OCC_MAX_RETRIES - 1:
                     raise
+                logger.debug(
+                    "DSQL OCC error (sqlstate=%s) on attempt %d/%d, retrying in %.1fs",
+                    self._get_sqlstate(e),
+                    attempt + 1,
+                    _OCC_MAX_RETRIES,
+                    _OCC_RETRY_DELAY,
+                )
                 self.connection.close()
                 self.connection.ensure_connection()
                 time.sleep(_OCC_RETRY_DELAY)
+
+    def _query_with_retry(self, sql, params=None):
+        """Execute a read query with OCC retry, returning all rows."""
+
+        def _do_query():
+            with self.connection.cursor() as cursor:
+                cursor.execute(sql, params)
+                return cursor.fetchall()
+
+        return self._occ_retry(_do_query)
 
     def _table_exists(self, table_name):
         """Check whether a table exists in the current schema."""

--- a/python/django/aurora_dsql_django/schema.py
+++ b/python/django/aurora_dsql_django/schema.py
@@ -414,6 +414,9 @@ class DatabaseSchemaEditor(schema.DatabaseSchemaEditor):
 
         # Step 2: Create the new table with the updated schema.
         # This adds deferred SQL (indexes) referencing new__<table>.
+        # Track where new deferred SQL starts so we only flush what
+        # create_model adds, preserving deferred SQL from other tables.
+        pre_deferred_count = len(self.deferred_sql)
         self.create_model(new_model)
 
         # Step 3: Copy data from the frozen old table into the new table.
@@ -483,9 +486,12 @@ class DatabaseSchemaEditor(schema.DatabaseSchemaEditor):
         # Step 6: Run deferred SQL (indexes) on the correctly-named table.
         # Each execute() auto-commits (can_rollback_ddl = False), so each
         # CREATE INDEX ASYNC runs in its own transaction as DSQL requires.
-        for sql in self.deferred_sql:
+        # Only flush SQL added by create_model for this table; preserve
+        # deferred SQL from other tables queued earlier in the session.
+        remake_deferred = self.deferred_sql[pre_deferred_count:]
+        self.deferred_sql = self.deferred_sql[:pre_deferred_count]
+        for sql in remake_deferred:
             self.execute(sql)
-        self.deferred_sql = []
         # Fix any PK-removed field
         if restore_pk_field:
             restore_pk_field.primary_key = True

--- a/python/django/aurora_dsql_django/schema.py
+++ b/python/django/aurora_dsql_django/schema.py
@@ -29,7 +29,7 @@ logger = logging.getLogger(__name__)
 _OCC_MAX_RETRIES = 3
 _OCC_RETRY_DELAY = 1.0
 
-# DSQL has a ~3000 row limit per transaction. Use a smaller batch size
+# DSQL has a 3000 row limit per transaction. Use a smaller batch size
 # to stay well within the limit when copying data during table recreation.
 _COPY_BATCH_SIZE = 1000
 
@@ -366,7 +366,7 @@ class DatabaseSchemaEditor(schema.DatabaseSchemaEditor):
         self.create_model(new_model)
 
         # Step 3: Copy data from the frozen old table into the new table.
-        # DSQL has a ~3000 row limit per transaction. Copy in batches to
+        # DSQL has a 3000 row limit per transaction. Copy in batches to
         # stay within the limit. Each batch auto-commits independently
         # (can_rollback_ddl = False). ORDER BY the primary key guarantees
         # deterministic, non-overlapping slices across batches.

--- a/python/django/aurora_dsql_django/schema.py
+++ b/python/django/aurora_dsql_django/schema.py
@@ -139,6 +139,7 @@ class DatabaseSchemaEditor(schema.DatabaseSchemaEditor):
     # For migrations that require these, we recreate the table with the new
     # schema and copy data across. This uses a rename-first pattern to
     # prevent silent data loss from concurrent writes:
+    #   0. Recover from any prior failed attempt (detect + rename back)
     #   1. RENAME original → old__<table>  (freezes the source)
     #   2. CREATE new__<table>             (new schema)
     #   3. INSERT INTO new__<table> SELECT FROM old__<table> (batched)
@@ -154,7 +155,21 @@ class DatabaseSchemaEditor(schema.DatabaseSchemaEditor):
     # call auto-commits independently. This naturally satisfies DSQL's
     # one-DDL-per-transaction rule without any special transaction handling.
     # OCC errors (OC000/OC001) are retried automatically via execute().
+    #
+    # WARNING: This is designed for development iteration, not production
+    # use on tables with significant data. The table is unavailable during
+    # the recreation window, and the batched copy holds no cross-batch
+    # transactional guarantee.
     # -------------------------------------------------------------------------
+
+    def _table_exists(self, table_name):
+        """Check whether a table exists in the database."""
+        with self.connection.cursor() as cursor:
+            cursor.execute(
+                "SELECT 1 FROM information_schema.tables WHERE table_name = %s",
+                [strip_quotes(table_name)],
+            )
+            return cursor.fetchone() is not None
 
     def _remake_table(self, model, create_field=None, delete_field=None, alter_fields=None):
         """
@@ -166,17 +181,30 @@ class DatabaseSchemaEditor(schema.DatabaseSchemaEditor):
         it before copying data.
 
         The pattern:
+          0. Recover from any previous failed _remake_table attempt
           1. Rename the original table to "old__<table>" (freezes writes)
-          2. Clean up any leftover "new__<table>" from a previous failure
-          3. Create "new__<table>" with the updated schema
-          4. Copy data from "old__<table>" into "new__<table>"
-          5. Drop "old__<table>"
-          6. Rename "new__<table>" to the original name
-          7. Restore indexes via deferred SQL
+          2. Create "new__<table>" with the updated schema
+          3. Copy data from "old__<table>" into "new__<table>" (batched)
+          4. Drop "old__<table>"
+          5. Rename "new__<table>" to the original name
+          6. Restore indexes via deferred SQL
 
-        Availability drops temporarily between steps 1 and 6 (the original
+        Availability drops temporarily between steps 1 and 5 (the original
         table name doesn't exist), but no data is silently lost -- writes
         to the old name fail loudly instead of disappearing.
+
+        If the process fails partway through, rerunning ``migrate`` will
+        recover automatically: step 0 detects leftover temp tables and
+        restores the original table name before proceeding.
+
+        .. warning::
+
+            This is designed for **development and iteration**, not
+            production use on tables with significant data. The table is
+            unavailable under its original name during the recreation
+            window, and the batched copy holds no cross-batch transactional
+            guarantee. For production schema changes, consider blue/green
+            deployments or manual migration strategies.
         """
         # Work out the new fields dict / mapping
         body = {f.name: f for f in model._meta.local_concrete_fields}
@@ -285,19 +313,63 @@ class DatabaseSchemaEditor(schema.DatabaseSchemaEditor):
 
         original_table = model._meta.db_table
         old_table = f"old__{strip_quotes(original_table)}"
+        new_table = new_model._meta.db_table
 
-        # Step 1: Clean up any leftover temp tables from a previous failed run.
-        self.execute(f"DROP TABLE IF EXISTS {self.quote_name(old_table)}")
-        self.execute(f"DROP TABLE IF EXISTS {self.quote_name(new_model._meta.db_table)}")
+        # Step 0: Recover from a previous failed _remake_table.
+        #
+        # If the original table doesn't exist, a prior run failed partway
+        # through. Detect the state and recover rather than losing data.
+        original_exists = self._table_exists(original_table)
+        old_exists = self._table_exists(old_table)
+        new_exists = self._table_exists(new_table)
 
-        # Step 2: Rename the original table to freeze it against concurrent writes.
+        if not original_exists:
+            if new_exists and not old_exists:
+                # Failed after DROP old__ but before RENAME new__ → original.
+                # new__table has all the data. Just rename it back.
+                logger.warning(
+                    "Recovering _remake_table for %s: renaming %s back to %s",
+                    original_table,
+                    new_table,
+                    original_table,
+                )
+                self.execute(f"ALTER TABLE {self.quote_name(new_table)} RENAME TO {self.quote_name(original_table)}")
+                # Clean up deferred SQL from the partial run, then fall
+                # through to redo the full _remake_table from scratch.
+                self.deferred_sql = []
+            elif old_exists:
+                # Failed after RENAME original → old__ but before completing.
+                # old__table has the data. Rename it back to the original.
+                logger.warning(
+                    "Recovering _remake_table for %s: renaming %s back to %s",
+                    original_table,
+                    old_table,
+                    original_table,
+                )
+                self.execute(f"DROP TABLE IF EXISTS {self.quote_name(new_table)}")
+                self.execute(f"ALTER TABLE {self.quote_name(old_table)} RENAME TO {self.quote_name(original_table)}")
+                self.deferred_sql = []
+            else:
+                raise RuntimeError(
+                    f"Cannot recover _remake_table for '{original_table}': "
+                    f"none of '{original_table}', '{old_table}', or "
+                    f"'{new_table}' exist. Manual intervention required."
+                )
+        else:
+            # Original table exists. Safe to clean up any leftover temp tables.
+            if old_exists:
+                self.execute(f"DROP TABLE IF EXISTS {self.quote_name(old_table)}")
+            if new_exists:
+                self.execute(f"DROP TABLE IF EXISTS {self.quote_name(new_table)}")
+
+        # Step 1: Rename the original table to freeze it against concurrent writes.
         # Any writes to the original table name will now fail loudly.
         self.execute(f"ALTER TABLE {self.quote_name(original_table)} RENAME TO {self.quote_name(old_table)}")
 
-        # Step 3: Create the new table with the updated schema.
+        # Step 2: Create the new table with the updated schema.
         self.create_model(new_model)
 
-        # Step 4: Copy data from the frozen old table into the new table.
+        # Step 3: Copy data from the frozen old table into the new table.
         # DSQL has a ~3000 row limit per transaction. Copy in batches to
         # stay within the limit. Each batch auto-commits independently
         # (can_rollback_ddl = False). The source table is frozen (renamed),
@@ -318,21 +390,21 @@ class DatabaseSchemaEditor(schema.DatabaseSchemaEditor):
                 f" LIMIT {_COPY_BATCH_SIZE} OFFSET {offset}"
             )
 
-        # Step 5: Drop the old (frozen) table.
+        # Step 4: Drop the old (frozen) table.
         self.execute(self.sql_delete_table % {"table": self.quote_name(old_table)})
         # Remove any deferred statements referencing the old table.
         for sql in list(self.deferred_sql):
             if isinstance(sql, Statement) and sql.references_table(original_table):
                 self.deferred_sql.remove(sql)
 
-        # Step 6: Rename the new table to the original name.
+        # Step 5: Rename the new table to the original name.
         self.alter_db_table(
             new_model,
             new_model._meta.db_table,
             original_table,
         )
 
-        # Step 7: Run deferred SQL (indexes) on the correctly-named table.
+        # Step 6: Run deferred SQL (indexes) on the correctly-named table.
         # Each execute() auto-commits (can_rollback_ddl = False), so each
         # CREATE INDEX ASYNC runs in its own transaction as DSQL requires.
         for sql in self.deferred_sql:

--- a/python/django/aurora_dsql_django/schema.py
+++ b/python/django/aurora_dsql_django/schema.py
@@ -362,6 +362,14 @@ class DatabaseSchemaEditor(schema.DatabaseSchemaEditor):
         original_table = model._meta.db_table
         old_table = f"old__{strip_quotes(original_table)}"
         new_table = new_model._meta.db_table
+
+        if len(old_table) > 63 or len(new_table) > 63:
+            raise ValueError(
+                f"Cannot remake table '{original_table}': prefixed names "
+                f"exceed PostgreSQL's 63-byte identifier limit. "
+                f"Rename the table to a shorter name first."
+            )
+
         remake_tables = (original_table, old_table, new_table)
 
         def _clear_deferred_sql_for_remake():

--- a/python/django/aurora_dsql_django/schema.py
+++ b/python/django/aurora_dsql_django/schema.py
@@ -12,13 +12,18 @@ adapted from Django's SQLite backend.
 """
 
 import copy
+import logging
+import time
 
 from django.apps.registry import Apps
+from django.db import OperationalError
 from django.db.backends.base.schema import BaseDatabaseSchemaEditor
 from django.db.backends.ddl_references import Statement
 from django.db.backends.postgresql import schema
 from django.db.backends.utils import strip_quotes
 from django.db.models import CheckConstraint
+
+logger = logging.getLogger(__name__)
 
 
 class DatabaseSchemaEditor(schema.DatabaseSchemaEditor):
@@ -51,6 +56,28 @@ class DatabaseSchemaEditor(schema.DatabaseSchemaEditor):
         # https://github.com/django/django/pull/15687#discussion_r1041503991.
         self.connection.ensure_connection()
         return self
+
+    def _execute_with_retry(self, fn, max_retries=3, delay=1.0):
+        """
+        Execute a callable with retries on OC001 (SerializationFailure).
+
+        DSQL may reject DDL that follows another DDL on the same schema
+        object because its schema cache hasn't propagated yet. The standard
+        fix is to retry after a brief delay.
+        """
+        for attempt in range(max_retries):
+            try:
+                return fn()
+            except OperationalError:
+                if attempt == max_retries - 1:
+                    raise
+                logger.debug(
+                    "OC001 on attempt %d/%d, retrying in %.1fs",
+                    attempt + 1,
+                    max_retries,
+                    delay,
+                )
+                time.sleep(delay)
 
     def add_index(self, model, index, concurrently=False):
         if index.contains_expressions and not self.connection.features.supports_expression_indexes:
@@ -243,18 +270,22 @@ class DatabaseSchemaEditor(schema.DatabaseSchemaEditor):
         # Delete the old table
         self.delete_model(model, handle_autom2m=False)
 
-        # Rename the new table to the original name
-        self.alter_db_table(
-            new_model,
-            new_model._meta.db_table,
-            model._meta.db_table,
+        # Rename the new table to the original name.
+        # The preceding DROP may trigger an OC001 (SerializationFailure)
+        # because DSQL's schema cache hasn't propagated yet. Retry briefly.
+        self._execute_with_retry(
+            lambda: self.alter_db_table(
+                new_model,
+                new_model._meta.db_table,
+                model._meta.db_table,
+            )
         )
 
         # Run deferred SQL (indexes) on the correctly-named table.
         # Each execute() auto-commits (can_rollback_ddl = False), so each
         # CREATE INDEX ASYNC runs in its own transaction as DSQL requires.
         for sql in self.deferred_sql:
-            self.execute(sql)
+            self._execute_with_retry(lambda sql=sql: self.execute(sql))
         self.deferred_sql = []
         # Fix any PK-removed field
         if restore_pk_field:

--- a/python/django/aurora_dsql_django/schema.py
+++ b/python/django/aurora_dsql_django/schema.py
@@ -381,12 +381,13 @@ class DatabaseSchemaEditor(schema.DatabaseSchemaEditor):
         # Step 3: Copy data from the frozen old table into the new table.
         # DSQL has a ~3000 row limit per transaction. Copy in batches to
         # stay within the limit. Each batch auto-commits independently
-        # (can_rollback_ddl = False). The source table is frozen (renamed),
-        # so the OFFSET-based pagination is stable.
+        # (can_rollback_ddl = False). ORDER BY the primary key guarantees
+        # deterministic, non-overlapping slices across batches.
         dst_cols = ", ".join(self.quote_name(x) for x in mapping)
         src_exprs = ", ".join(mapping.values())
         dst_table = self.quote_name(new_model._meta.db_table)
         src_table = self.quote_name(old_table)
+        order_by = self.quote_name(model._meta.pk.column)
 
         with self.connection.cursor() as cursor:
             cursor.execute(f"SELECT COUNT(*) FROM {src_table}")
@@ -396,8 +397,24 @@ class DatabaseSchemaEditor(schema.DatabaseSchemaEditor):
             self.execute(
                 f"INSERT INTO {dst_table} ({dst_cols})"
                 f" SELECT {src_exprs} FROM {src_table}"
+                f" ORDER BY {order_by}"
                 f" LIMIT {_COPY_BATCH_SIZE} OFFSET {offset}"
             )
+
+        # Verify the copy is complete before dropping the source.
+        if total_rows > 0:
+            with self.connection.cursor() as cursor:
+                cursor.execute(f"SELECT COUNT(*) FROM {dst_table}")
+                copied_rows = cursor.fetchone()[0]
+            if copied_rows != total_rows:
+                # Abort: recover by renaming old__ back to original.
+                self.execute(f"DROP TABLE IF EXISTS {dst_table}")
+                self.execute(f"ALTER TABLE {self.quote_name(old_table)} RENAME TO {self.quote_name(original_table)}")
+                raise RuntimeError(
+                    f"_remake_table copy verification failed for "
+                    f"'{original_table}': expected {total_rows} rows, "
+                    f"got {copied_rows}. Original table has been restored."
+                )
 
         # Step 4: Drop the old (frozen) table.
         self.execute(self.sql_delete_table % {"table": self.quote_name(old_table)})

--- a/python/django/aurora_dsql_django/schema.py
+++ b/python/django/aurora_dsql_django/schema.py
@@ -29,6 +29,10 @@ logger = logging.getLogger(__name__)
 _OCC_MAX_RETRIES = 3
 _OCC_RETRY_DELAY = 1.0
 
+# DSQL has a 3000 row limit per transaction. Use a smaller batch size
+# to stay well within the limit when copying data during table recreation.
+_COPY_BATCH_SIZE = 1000
+
 
 class DatabaseSchemaEditor(schema.DatabaseSchemaEditor):
     """
@@ -137,7 +141,7 @@ class DatabaseSchemaEditor(schema.DatabaseSchemaEditor):
     # prevent silent data loss from concurrent writes:
     #   1. RENAME original → old__<table>  (freezes the source)
     #   2. CREATE new__<table>             (new schema)
-    #   3. INSERT INTO new__<table> SELECT FROM old__<table>
+    #   3. INSERT INTO new__<table> SELECT FROM old__<table> (batched)
     #   4. DROP old__<table>
     #   5. RENAME new__<table> → original
     #
@@ -294,14 +298,25 @@ class DatabaseSchemaEditor(schema.DatabaseSchemaEditor):
         self.create_model(new_model)
 
         # Step 4: Copy data from the frozen old table into the new table.
-        self.execute(
-            "INSERT INTO {} ({}) SELECT {} FROM {}".format(
-                self.quote_name(new_model._meta.db_table),
-                ", ".join(self.quote_name(x) for x in mapping),
-                ", ".join(mapping.values()),
-                self.quote_name(old_table),
+        # DSQL has a ~3000 row limit per transaction. Copy in batches to
+        # stay within the limit. Each batch auto-commits independently
+        # (can_rollback_ddl = False). The source table is frozen (renamed),
+        # so the OFFSET-based pagination is stable.
+        dst_cols = ", ".join(self.quote_name(x) for x in mapping)
+        src_exprs = ", ".join(mapping.values())
+        dst_table = self.quote_name(new_model._meta.db_table)
+        src_table = self.quote_name(old_table)
+
+        with self.connection.cursor() as cursor:
+            cursor.execute(f"SELECT COUNT(*) FROM {src_table}")
+            total_rows = cursor.fetchone()[0]
+
+        for offset in range(0, max(total_rows, 1), _COPY_BATCH_SIZE):
+            self.execute(
+                f"INSERT INTO {dst_table} ({dst_cols})"
+                f" SELECT {src_exprs} FROM {src_table}"
+                f" LIMIT {_COPY_BATCH_SIZE} OFFSET {offset}"
             )
-        )
 
         # Step 5: Drop the old (frozen) table.
         self.execute(self.sql_delete_table % {"table": self.quote_name(old_table)})

--- a/python/django/aurora_dsql_django/schema.py
+++ b/python/django/aurora_dsql_django/schema.py
@@ -25,6 +25,10 @@ from django.db.models import CheckConstraint
 
 logger = logging.getLogger(__name__)
 
+# OCC retry settings for DSQL schema operations.
+_OCC_MAX_RETRIES = 3
+_OCC_RETRY_DELAY = 1.0
+
 
 class DatabaseSchemaEditor(schema.DatabaseSchemaEditor):
     """
@@ -57,29 +61,29 @@ class DatabaseSchemaEditor(schema.DatabaseSchemaEditor):
         self.connection.ensure_connection()
         return self
 
-    def _execute_with_retry(self, fn, max_retries=3, delay=1.0):
+    def execute(self, sql, params=()):
         """
-        Execute a callable with retries on OC001 (SerializationFailure).
+        Execute SQL with automatic retry on DSQL OCC errors.
 
-        DSQL may reject DDL that follows another DDL on the same schema
-        object because its schema cache hasn't propagated yet. The standard
-        fix is to retry after a brief delay.
+        DSQL may reject operations with SerializationFailure (OC000/OC001)
+        when concurrent schema changes conflict. Since can_rollback_ddl=False,
+        each execute() auto-commits independently, making retries safe.
         """
-        for attempt in range(max_retries):
+        for attempt in range(_OCC_MAX_RETRIES):
             try:
-                return fn()
+                return super().execute(sql, params)
             except OperationalError:
-                if attempt == max_retries - 1:
+                if attempt == _OCC_MAX_RETRIES - 1:
                     raise
                 logger.debug(
-                    "OC001 on attempt %d/%d, retrying in %.1fs",
+                    "DSQL OCC error on attempt %d/%d, retrying in %.1fs",
                     attempt + 1,
-                    max_retries,
-                    delay,
+                    _OCC_MAX_RETRIES,
+                    _OCC_RETRY_DELAY,
                 )
                 self.connection.close()
                 self.connection.ensure_connection()
-                time.sleep(delay)
+                time.sleep(_OCC_RETRY_DELAY)
 
     def add_index(self, model, index, concurrently=False):
         if index.contains_expressions and not self.connection.features.supports_expression_indexes:
@@ -138,6 +142,7 @@ class DatabaseSchemaEditor(schema.DatabaseSchemaEditor):
     # Transaction safety: since can_rollback_ddl = False, each self.execute()
     # call auto-commits independently. This naturally satisfies DSQL's
     # one-DDL-per-transaction rule without any special transaction handling.
+    # OCC errors (OC000/OC001) are retried automatically via execute().
     # -------------------------------------------------------------------------
 
     def _remake_table(self, model, create_field=None, delete_field=None, alter_fields=None):
@@ -192,7 +197,7 @@ class DatabaseSchemaEditor(schema.DatabaseSchemaEditor):
             if new_field.generated:
                 continue
             if old_field.null and not new_field.null:
-                # Transitioning from NULL to NOT NULL — use coalesce to fill
+                # Transitioning from NULL to NOT NULL -- use coalesce to fill
                 # existing NULLs with the new default.
                 if not new_field.has_db_default():
                     default = self.quote_value(self.effective_default(new_field))
@@ -278,21 +283,17 @@ class DatabaseSchemaEditor(schema.DatabaseSchemaEditor):
         self.delete_model(model, handle_autom2m=False)
 
         # Rename the new table to the original name.
-        # The preceding DROP may trigger an OC001 (SerializationFailure)
-        # because DSQL's schema cache hasn't propagated yet. Retry briefly.
-        self._execute_with_retry(
-            lambda: self.alter_db_table(
-                new_model,
-                new_model._meta.db_table,
-                model._meta.db_table,
-            )
+        self.alter_db_table(
+            new_model,
+            new_model._meta.db_table,
+            model._meta.db_table,
         )
 
         # Run deferred SQL (indexes) on the correctly-named table.
         # Each execute() auto-commits (can_rollback_ddl = False), so each
         # CREATE INDEX ASYNC runs in its own transaction as DSQL requires.
         for sql in self.deferred_sql:
-            self._execute_with_retry(lambda sql=sql: self.execute(sql))
+            self.execute(sql)
         self.deferred_sql = []
         # Fix any PK-removed field
         if restore_pk_field:
@@ -303,7 +304,7 @@ class DatabaseSchemaEditor(schema.DatabaseSchemaEditor):
         if handle_autom2m:
             super().delete_model(model)
         else:
-            # Delete the table only (no M2M cleanup) — used by _remake_table.
+            # Delete the table only (no M2M cleanup) -- used by _remake_table.
             self.execute(
                 self.sql_delete_table
                 % {
@@ -343,7 +344,7 @@ class DatabaseSchemaEditor(schema.DatabaseSchemaEditor):
         """
         Add a field to a model.
 
-        Aurora DSQL's ADD COLUMN only supports 'column_name data_type' — no
+        Aurora DSQL's ADD COLUMN only supports 'column_name data_type' -- no
         DEFAULT, NOT NULL, UNIQUE, or PRIMARY KEY inline. Fields requiring
         any of these use table recreation instead.
         """
@@ -370,7 +371,7 @@ class DatabaseSchemaEditor(schema.DatabaseSchemaEditor):
         Aurora DSQL does not support ALTER TABLE DROP COLUMN, so non-M2M
         field removal requires table recreation.
         """
-        # M2M fields are a special case — just drop the through table.
+        # M2M fields are a special case -- just drop the through table.
         if field.many_to_many:
             if field.remote_field.through._meta.auto_created:
                 self.delete_model(field.remote_field.through)

--- a/python/django/aurora_dsql_django/schema.py
+++ b/python/django/aurora_dsql_django/schema.py
@@ -77,6 +77,8 @@ class DatabaseSchemaEditor(schema.DatabaseSchemaEditor):
                     max_retries,
                     delay,
                 )
+                self.connection.close()
+                self.connection.ensure_connection()
                 time.sleep(delay)
 
     def add_index(self, model, index, concurrently=False):
@@ -253,6 +255,11 @@ class DatabaseSchemaEditor(schema.DatabaseSchemaEditor):
         body_copy["Meta"] = meta
         body_copy["__module__"] = model.__module__
         new_model = type(f"New{model._meta.object_name}", model.__bases__, body_copy)
+
+        # Drop any leftover temp table from a previous failed _remake_table.
+        self.execute(
+            f"DROP TABLE IF EXISTS {self.quote_name(new_model._meta.db_table)}"
+        )
 
         # Create a new table with the updated schema.
         self.create_model(new_model)

--- a/python/django/aurora_dsql_django/schema.py
+++ b/python/django/aurora_dsql_django/schema.py
@@ -4,10 +4,20 @@
 """
 This module customizes the default Django database schema editor functions
 for Aurora DSQL.
+
+Aurora DSQL does not support ALTER COLUMN (TYPE, SET/DROP NOT NULL,
+SET/DROP DEFAULT) or DROP COLUMN. To handle migrations that require
+these operations, this module implements a table-recreation pattern
+adapted from Django's SQLite backend.
 """
 
+import copy
+
+from django.apps.registry import Apps
 from django.db.backends.base.schema import BaseDatabaseSchemaEditor
+from django.db.backends.ddl_references import Statement
 from django.db.backends.postgresql import schema
+from django.db.backends.utils import strip_quotes
 from django.db.models import CheckConstraint
 
 
@@ -79,3 +89,255 @@ class DatabaseSchemaEditor(schema.DatabaseSchemaEditor):
         # Aurora DSQL doesn't support LIKE indexes which use postgres
         # opsclasses
         return None
+
+    # -------------------------------------------------------------------------
+    # Table recreation pattern for unsupported ALTER TABLE operations.
+    #
+    # Aurora DSQL does not support:
+    #   - ALTER COLUMN ... TYPE
+    #   - ALTER COLUMN ... SET/DROP NOT NULL
+    #   - ALTER COLUMN ... SET/DROP DEFAULT
+    #   - DROP COLUMN
+    #
+    # For migrations that require these, we recreate the table with the new
+    # schema and copy data across. This is adapted from Django's SQLite
+    # backend (_remake_table) but simplified for DSQL:
+    #   - No foreign key handling (DSQL doesn't support FKs)
+    #   - No check constraint handling (already skipped via _check_sql)
+    #   - Uses quote_value instead of prepare_default (PostgreSQL-style quoting)
+    #
+    # Transaction safety: since can_rollback_ddl = False, each self.execute()
+    # call auto-commits independently. This naturally satisfies DSQL's
+    # one-DDL-per-transaction rule without any special transaction handling.
+    # -------------------------------------------------------------------------
+
+    def _remake_table(self, model, create_field=None, delete_field=None, alter_fields=None):
+        """
+        Recreate a table with modified schema.
+
+        This follows the pattern:
+          1. Create a table with the updated definition called "new__<table>"
+          2. Copy data from the existing table to the new table
+          3. Drop the old table
+          4. Rename the new table to the original name
+          5. Restore indexes via deferred SQL
+        """
+        # Work out the new fields dict / mapping
+        body = {f.name: f for f in model._meta.local_concrete_fields}
+        # Since mapping might mix column names and default values,
+        # its values must be already quoted.
+        mapping = {f.column: self.quote_name(f.column) for f in model._meta.local_concrete_fields if f.generated is False}
+        # This maps field names (not columns) for things like unique_together
+        rename_mapping = {}
+        # If any of the new or altered fields is introducing a new PK,
+        # remove the old one
+        restore_pk_field = None
+        alter_fields = alter_fields or []
+        if getattr(create_field, "primary_key", False) or any(
+            getattr(new_field, "primary_key", False) for _, new_field in alter_fields
+        ):
+            for name, field in list(body.items()):
+                if field.primary_key and not any(name == new_field.name for _, new_field in alter_fields):
+                    field.primary_key = False
+                    restore_pk_field = field
+                    if field.auto_created:
+                        del body[name]
+                        del mapping[field.column]
+        # Add in any created fields
+        if create_field:
+            body[create_field.name] = create_field
+            # Choose a default and insert it into the copy map
+            if (
+                not create_field.has_db_default()
+                and not (create_field.many_to_many or create_field.generated)
+                and create_field.concrete
+            ):
+                mapping[create_field.column] = self.quote_value(self.effective_default(create_field))
+        # Add in any altered fields
+        for alter_field in alter_fields:
+            old_field, new_field = alter_field
+            body.pop(old_field.name, None)
+            mapping.pop(old_field.column, None)
+            body[new_field.name] = new_field
+            rename_mapping[old_field.name] = new_field.name
+            if new_field.generated:
+                continue
+            if old_field.null and not new_field.null:
+                # Transitioning from NULL to NOT NULL — use coalesce to fill
+                # existing NULLs with the new default.
+                if not new_field.has_db_default():
+                    default = self.quote_value(self.effective_default(new_field))
+                else:
+                    default, _ = self.db_default_sql(new_field)
+                case_sql = f"coalesce({self.quote_name(old_field.column)}, {default})"
+                mapping[new_field.column] = case_sql
+            else:
+                mapping[new_field.column] = self.quote_name(old_field.column)
+        # Remove any deleted fields
+        if delete_field:
+            del body[delete_field.name]
+            mapping.pop(delete_field.column, None)
+            # Remove any implicit M2M tables
+            if delete_field.many_to_many and delete_field.remote_field.through._meta.auto_created:
+                return self.delete_model(delete_field.remote_field.through)
+        # Work inside a new app registry
+        apps = Apps()
+
+        # Work out the new value of unique_together, taking renames into
+        # account
+        unique_together = [[rename_mapping.get(n, n) for n in unique] for unique in model._meta.unique_together]
+
+        indexes = model._meta.indexes
+        if delete_field:
+            indexes = [index for index in indexes if delete_field.name not in index.fields]
+
+        constraints = list(model._meta.constraints)
+
+        # Provide isolated instances of the fields to the new model body so
+        # that the existing model's internals aren't interfered with when
+        # the dummy model is constructed.
+        body_copy = copy.deepcopy(body)
+
+        # Construct a new model for FK resolution (never materialized as a table).
+        meta_contents = {
+            "app_label": model._meta.app_label,
+            "db_table": model._meta.db_table,
+            "unique_together": unique_together,
+            "indexes": indexes,
+            "constraints": constraints,
+            "apps": apps,
+        }
+        meta = type("Meta", (), meta_contents)
+        body_copy["Meta"] = meta
+        body_copy["__module__"] = model.__module__
+        type(model._meta.object_name, model.__bases__, body_copy)
+
+        # Construct a model with a renamed table name.
+        body_copy = copy.deepcopy(body)
+        meta_contents = {
+            "app_label": model._meta.app_label,
+            "db_table": f"new__{strip_quotes(model._meta.db_table)}",
+            "unique_together": unique_together,
+            "indexes": indexes,
+            "constraints": constraints,
+            "apps": apps,
+        }
+        meta = type("Meta", (), meta_contents)
+        body_copy["Meta"] = meta
+        body_copy["__module__"] = model.__module__
+        new_model = type(f"New{model._meta.object_name}", model.__bases__, body_copy)
+
+        # Create a new table with the updated schema.
+        self.create_model(new_model)
+
+        # Copy data from the old table into the new table
+        self.execute(
+            "INSERT INTO {} ({}) SELECT {} FROM {}".format(
+                self.quote_name(new_model._meta.db_table),
+                ", ".join(self.quote_name(x) for x in mapping),
+                ", ".join(mapping.values()),
+                self.quote_name(model._meta.db_table),
+            )
+        )
+
+        # Delete the old table
+        self.delete_model(model, handle_autom2m=False)
+
+        # Rename the new table to the original name
+        self.alter_db_table(
+            new_model,
+            new_model._meta.db_table,
+            model._meta.db_table,
+        )
+
+        # Run deferred SQL (indexes) on the correctly-named table.
+        # Each execute() auto-commits (can_rollback_ddl = False), so each
+        # CREATE INDEX ASYNC runs in its own transaction as DSQL requires.
+        for sql in self.deferred_sql:
+            self.execute(sql)
+        self.deferred_sql = []
+        # Fix any PK-removed field
+        if restore_pk_field:
+            restore_pk_field.primary_key = True
+
+    def delete_model(self, model, handle_autom2m=True):
+        """Delete a model from the database, with optional M2M handling."""
+        if handle_autom2m:
+            super().delete_model(model)
+        else:
+            # Delete the table only (no M2M cleanup) — used by _remake_table.
+            self.execute(
+                self.sql_delete_table
+                % {
+                    "table": self.quote_name(model._meta.db_table),
+                }
+            )
+            # Remove all deferred statements referencing the deleted table.
+            for sql in list(self.deferred_sql):
+                if isinstance(sql, Statement) and sql.references_table(model._meta.db_table):
+                    self.deferred_sql.remove(sql)
+
+    def _alter_field(
+        self,
+        model,
+        old_field,
+        new_field,
+        old_type,
+        new_type,
+        old_db_params,
+        new_db_params,
+        strict=False,
+    ):
+        """
+        Perform a physical (non-ManyToMany) field update.
+
+        Aurora DSQL does not support ALTER COLUMN operations (TYPE changes,
+        nullability changes, default changes). Use RENAME COLUMN for pure
+        renames; otherwise recreate the table.
+        """
+        # Use "ALTER TABLE ... RENAME COLUMN" if only the column name changed.
+        if old_field.column != new_field.column and self.column_sql(model, old_field) == self.column_sql(model, new_field):
+            return self.execute(self._rename_field_sql(model._meta.db_table, old_field, new_field, new_type))
+        # Everything else: recreate the table.
+        self._remake_table(model, alter_fields=[(old_field, new_field)])
+
+    def add_field(self, model, field):
+        """
+        Add a field to a model.
+
+        Aurora DSQL's ADD COLUMN only supports 'column_name data_type' — no
+        DEFAULT, NOT NULL, UNIQUE, or PRIMARY KEY inline. Fields requiring
+        any of these use table recreation instead.
+        """
+        from django.db.models.expressions import Value
+
+        # M2M fields create a separate through table.
+        if field.many_to_many and field.remote_field.through._meta.auto_created:
+            self.create_model(field.remote_field.through)
+        elif (
+            field.primary_key
+            or field.unique
+            or not field.null
+            or self.effective_default(field) is not None
+            or (field.has_db_default() and not isinstance(field.db_default, Value))
+        ):
+            self._remake_table(model, create_field=field)
+        else:
+            super().add_field(model, field)
+
+    def remove_field(self, model, field):
+        """
+        Remove a field from a model.
+
+        Aurora DSQL does not support ALTER TABLE DROP COLUMN, so non-M2M
+        field removal requires table recreation.
+        """
+        # M2M fields are a special case — just drop the through table.
+        if field.many_to_many:
+            if field.remote_field.through._meta.auto_created:
+                self.delete_model(field.remote_field.through)
+            return
+        # It might not actually have a column behind it
+        if field.db_parameters(connection=self.connection)["type"] is None:
+            return
+        self._remake_table(model, delete_field=field)

--- a/python/django/aurora_dsql_django/schema.py
+++ b/python/django/aurora_dsql_django/schema.py
@@ -163,10 +163,10 @@ class DatabaseSchemaEditor(schema.DatabaseSchemaEditor):
     # -------------------------------------------------------------------------
 
     def _table_exists(self, table_name):
-        """Check whether a table exists in the database."""
+        """Check whether a table exists in the current schema."""
         with self.connection.cursor() as cursor:
             cursor.execute(
-                "SELECT 1 FROM information_schema.tables WHERE table_name = %s",
+                "SELECT 1 FROM information_schema.tables WHERE table_schema = current_schema() AND table_name = %s",
                 [strip_quotes(table_name)],
             )
             return cursor.fetchone() is not None
@@ -362,11 +362,20 @@ class DatabaseSchemaEditor(schema.DatabaseSchemaEditor):
             if new_exists:
                 self.execute(f"DROP TABLE IF EXISTS {self.quote_name(new_table)}")
 
+        # Remove any pre-existing deferred SQL for the original table
+        # (from earlier operations in this schema editor session) before we
+        # replace it. create_model() below will generate fresh deferred SQL
+        # for the new table, and alter_db_table() will rename those references.
+        for sql in list(self.deferred_sql):
+            if isinstance(sql, Statement) and sql.references_table(original_table):
+                self.deferred_sql.remove(sql)
+
         # Step 1: Rename the original table to freeze it against concurrent writes.
         # Any writes to the original table name will now fail loudly.
         self.execute(f"ALTER TABLE {self.quote_name(original_table)} RENAME TO {self.quote_name(old_table)}")
 
         # Step 2: Create the new table with the updated schema.
+        # This adds deferred SQL (indexes) referencing new__<table>.
         self.create_model(new_model)
 
         # Step 3: Copy data from the frozen old table into the new table.
@@ -383,7 +392,7 @@ class DatabaseSchemaEditor(schema.DatabaseSchemaEditor):
             cursor.execute(f"SELECT COUNT(*) FROM {src_table}")
             total_rows = cursor.fetchone()[0]
 
-        for offset in range(0, max(total_rows, 1), _COPY_BATCH_SIZE):
+        for offset in range(0, total_rows, _COPY_BATCH_SIZE):
             self.execute(
                 f"INSERT INTO {dst_table} ({dst_cols})"
                 f" SELECT {src_exprs} FROM {src_table}"
@@ -392,12 +401,10 @@ class DatabaseSchemaEditor(schema.DatabaseSchemaEditor):
 
         # Step 4: Drop the old (frozen) table.
         self.execute(self.sql_delete_table % {"table": self.quote_name(old_table)})
-        # Remove any deferred statements referencing the old table.
-        for sql in list(self.deferred_sql):
-            if isinstance(sql, Statement) and sql.references_table(original_table):
-                self.deferred_sql.remove(sql)
 
         # Step 5: Rename the new table to the original name.
+        # alter_db_table also updates deferred SQL references from
+        # new__<table> to the original table name.
         self.alter_db_table(
             new_model,
             new_model._meta.db_table,
@@ -413,23 +420,6 @@ class DatabaseSchemaEditor(schema.DatabaseSchemaEditor):
         # Fix any PK-removed field
         if restore_pk_field:
             restore_pk_field.primary_key = True
-
-    def delete_model(self, model, handle_autom2m=True):
-        """Delete a model from the database, with optional M2M handling."""
-        if handle_autom2m:
-            super().delete_model(model)
-        else:
-            # Delete the table only (no M2M cleanup) -- used by _remake_table.
-            self.execute(
-                self.sql_delete_table
-                % {
-                    "table": self.quote_name(model._meta.db_table),
-                }
-            )
-            # Remove all deferred statements referencing the deleted table.
-            for sql in list(self.deferred_sql):
-                if isinstance(sql, Statement) and sql.references_table(model._meta.db_table):
-                    self.deferred_sql.remove(sql)
 
     def _alter_field(
         self,

--- a/python/django/aurora_dsql_django/schema.py
+++ b/python/django/aurora_dsql_django/schema.py
@@ -133,8 +133,15 @@ class DatabaseSchemaEditor(schema.DatabaseSchemaEditor):
     #   - DROP COLUMN
     #
     # For migrations that require these, we recreate the table with the new
-    # schema and copy data across. This is adapted from Django's SQLite
-    # backend (_remake_table) but simplified for DSQL:
+    # schema and copy data across. This uses a rename-first pattern to
+    # prevent silent data loss from concurrent writes:
+    #   1. RENAME original → old__<table>  (freezes the source)
+    #   2. CREATE new__<table>             (new schema)
+    #   3. INSERT INTO new__<table> SELECT FROM old__<table>
+    #   4. DROP old__<table>
+    #   5. RENAME new__<table> → original
+    #
+    # Adapted from Django's SQLite backend but simplified for DSQL:
     #   - No foreign key handling (DSQL doesn't support FKs)
     #   - No check constraint handling (already skipped via _check_sql)
     #   - Uses quote_value instead of prepare_default (PostgreSQL-style quoting)
@@ -147,14 +154,25 @@ class DatabaseSchemaEditor(schema.DatabaseSchemaEditor):
 
     def _remake_table(self, model, create_field=None, delete_field=None, alter_fields=None):
         """
-        Recreate a table with modified schema.
+        Recreate a table with modified schema using the rename-first pattern.
 
-        This follows the pattern:
-          1. Create a table with the updated definition called "new__<table>"
-          2. Copy data from the existing table to the new table
-          3. Drop the old table
-          4. Rename the new table to the original name
-          5. Restore indexes via deferred SQL
+        Aurora DSQL doesn't support ALTER COLUMN or DROP COLUMN. This method
+        recreates the table with the new schema. To prevent silent data loss
+        from concurrent writes, the original table is renamed first to freeze
+        it before copying data.
+
+        The pattern:
+          1. Rename the original table to "old__<table>" (freezes writes)
+          2. Clean up any leftover "new__<table>" from a previous failure
+          3. Create "new__<table>" with the updated schema
+          4. Copy data from "old__<table>" into "new__<table>"
+          5. Drop "old__<table>"
+          6. Rename "new__<table>" to the original name
+          7. Restore indexes via deferred SQL
+
+        Availability drops temporarily between steps 1 and 6 (the original
+        table name doesn't exist), but no data is silently lost -- writes
+        to the old name fail loudly instead of disappearing.
         """
         # Work out the new fields dict / mapping
         body = {f.name: f for f in model._meta.local_concrete_fields}
@@ -246,7 +264,7 @@ class DatabaseSchemaEditor(schema.DatabaseSchemaEditor):
         body_copy["__module__"] = model.__module__
         type(model._meta.object_name, model.__bases__, body_copy)
 
-        # Construct a model with a renamed table name.
+        # Construct a model with the new__<table> name for creating the new schema.
         body_copy = copy.deepcopy(body)
         meta_contents = {
             "app_label": model._meta.app_label,
@@ -261,33 +279,45 @@ class DatabaseSchemaEditor(schema.DatabaseSchemaEditor):
         body_copy["__module__"] = model.__module__
         new_model = type(f"New{model._meta.object_name}", model.__bases__, body_copy)
 
-        # Drop any leftover temp table from a previous failed _remake_table.
+        original_table = model._meta.db_table
+        old_table = f"old__{strip_quotes(original_table)}"
+
+        # Step 1: Clean up any leftover temp tables from a previous failed run.
+        self.execute(f"DROP TABLE IF EXISTS {self.quote_name(old_table)}")
         self.execute(f"DROP TABLE IF EXISTS {self.quote_name(new_model._meta.db_table)}")
 
-        # Create a new table with the updated schema.
+        # Step 2: Rename the original table to freeze it against concurrent writes.
+        # Any writes to the original table name will now fail loudly.
+        self.execute(f"ALTER TABLE {self.quote_name(original_table)} RENAME TO {self.quote_name(old_table)}")
+
+        # Step 3: Create the new table with the updated schema.
         self.create_model(new_model)
 
-        # Copy data from the old table into the new table
+        # Step 4: Copy data from the frozen old table into the new table.
         self.execute(
             "INSERT INTO {} ({}) SELECT {} FROM {}".format(
                 self.quote_name(new_model._meta.db_table),
                 ", ".join(self.quote_name(x) for x in mapping),
                 ", ".join(mapping.values()),
-                self.quote_name(model._meta.db_table),
+                self.quote_name(old_table),
             )
         )
 
-        # Delete the old table
-        self.delete_model(model, handle_autom2m=False)
+        # Step 5: Drop the old (frozen) table.
+        self.execute(self.sql_delete_table % {"table": self.quote_name(old_table)})
+        # Remove any deferred statements referencing the old table.
+        for sql in list(self.deferred_sql):
+            if isinstance(sql, Statement) and sql.references_table(original_table):
+                self.deferred_sql.remove(sql)
 
-        # Rename the new table to the original name.
+        # Step 6: Rename the new table to the original name.
         self.alter_db_table(
             new_model,
             new_model._meta.db_table,
-            model._meta.db_table,
+            original_table,
         )
 
-        # Run deferred SQL (indexes) on the correctly-named table.
+        # Step 7: Run deferred SQL (indexes) on the correctly-named table.
         # Each execute() auto-commits (can_rollback_ddl = False), so each
         # CREATE INDEX ASYNC runs in its own transaction as DSQL requires.
         for sql in self.deferred_sql:

--- a/python/django/aurora_dsql_django/schema.py
+++ b/python/django/aurora_dsql_django/schema.py
@@ -90,39 +90,31 @@ class DatabaseSchemaEditor(schema.DatabaseSchemaEditor):
         may survive a DROP TABLE, leaving an orphaned index name. When this
         happens, the existing index is dropped and the CREATE is retried.
         """
-        for attempt in range(_OCC_MAX_RETRIES):
+        _super_execute = super().execute
+        _index_dropped = False
+
+        def _do_execute():
+            nonlocal _index_dropped
             try:
-                return super().execute(sql, params)
+                return _super_execute(sql, params)
             except ProgrammingError as e:
                 # DSQL's ASYNC index creation can leave orphaned index names
                 # that survive DROP TABLE. If a CREATE INDEX hits "already
                 # exists" (42P07), drop the stale index and retry once.
                 sql_str = str(sql)
-                if attempt == 0 and self._get_sqlstate(e) == "42P07" and "INDEX" in sql_str:
-                    # Extract the index name: it's the first quoted identifier
-                    # after "INDEX" (or "INDEX ASYNC") in the SQL.
+                if not _index_dropped and self._get_sqlstate(e) == "42P07" and "INDEX" in sql_str:
                     match = re.search(r"INDEX\s+(?:ASYNC\s+)?(?:IF\s+NOT\s+EXISTS\s+)?(\S+)", sql_str)
                     if match:
                         index_name = strip_quotes(match.group(1))
                         logger.debug("Index %s already exists, dropping and retrying", index_name)
                         self.connection.close()
                         self.connection.ensure_connection()
-                        super().execute(f"DROP INDEX IF EXISTS {self.quote_name(index_name)}")
-                        continue
+                        _super_execute(f"DROP INDEX IF EXISTS {self.quote_name(index_name)}")
+                        _index_dropped = True
+                        return _super_execute(sql, params)
                 raise
-            except OperationalError as e:
-                if not self._is_occ_error(e) or attempt == _OCC_MAX_RETRIES - 1:
-                    raise
-                logger.debug(
-                    "DSQL OCC error (sqlstate=%s) on attempt %d/%d, retrying in %.1fs",
-                    self._get_sqlstate(e),
-                    attempt + 1,
-                    _OCC_MAX_RETRIES,
-                    _OCC_RETRY_DELAY,
-                )
-                self.connection.close()
-                self.connection.ensure_connection()
-                time.sleep(_OCC_RETRY_DELAY)
+
+        return self._occ_retry(_do_execute)
 
     def add_index(self, model, index, concurrently=False):
         if index.contains_expressions and not self.connection.features.supports_expression_indexes:
@@ -470,6 +462,13 @@ class DatabaseSchemaEditor(schema.DatabaseSchemaEditor):
                     f" LIMIT {_COPY_BATCH_SIZE}",
                     [last_pk],
                 )
+                copied += _COPY_BATCH_SIZE
+                logger.info(
+                    "_remake_table %s: copied %d/%d rows",
+                    original_table,
+                    min(copied, total_rows),
+                    total_rows,
+                )
                 # Advance the cursor past the batch we just copied.
                 rows = self._query_with_retry(
                     f"SELECT {q_pk} FROM {q_old} WHERE {q_pk} >= %s ORDER BY {q_pk} LIMIT 1 OFFSET {_COPY_BATCH_SIZE}",
@@ -478,7 +477,6 @@ class DatabaseSchemaEditor(schema.DatabaseSchemaEditor):
                 if not rows:
                     break  # No more rows
                 last_pk = rows[0][0]
-                copied += _COPY_BATCH_SIZE
 
             # Verify the copy is complete before dropping the source.
             copied_rows = self._query_with_retry(f"SELECT COUNT(*) FROM {q_new}")[0][0]

--- a/python/django/aurora_dsql_django/schema.py
+++ b/python/django/aurora_dsql_django/schema.py
@@ -206,14 +206,27 @@ class DatabaseSchemaEditor(schema.DatabaseSchemaEditor):
     # deployments or manual migration strategies.
     # -------------------------------------------------------------------------
 
+    def _query_with_retry(self, sql, params=None):
+        """Execute a read query with OCC retry, returning all rows."""
+        for attempt in range(_OCC_MAX_RETRIES):
+            try:
+                with self.connection.cursor() as cursor:
+                    cursor.execute(sql, params)
+                    return cursor.fetchall()
+            except OperationalError as e:
+                if not self._is_occ_error(e) or attempt == _OCC_MAX_RETRIES - 1:
+                    raise
+                self.connection.close()
+                self.connection.ensure_connection()
+                time.sleep(_OCC_RETRY_DELAY)
+
     def _table_exists(self, table_name):
         """Check whether a table exists in the current schema."""
-        with self.connection.cursor() as cursor:
-            cursor.execute(
-                "SELECT 1 FROM information_schema.tables WHERE table_schema = current_schema() AND table_name = %s",
-                [strip_quotes(table_name)],
-            )
-            return cursor.fetchone() is not None
+        rows = self._query_with_retry(
+            "SELECT 1 FROM information_schema.tables WHERE table_schema = current_schema() AND table_name = %s",
+            [strip_quotes(table_name)],
+        )
+        return len(rows) > 0
 
     def _remake_table(self, model, create_field=None, delete_field=None, alter_fields=None):
         """
@@ -429,15 +442,11 @@ class DatabaseSchemaEditor(schema.DatabaseSchemaEditor):
         q_old = self.quote_name(old_table)
         q_pk = self.quote_name(model._meta.pk.column)
 
-        with self.connection.cursor() as cursor:
-            cursor.execute(f"SELECT COUNT(*) FROM {q_old}")
-            total_rows = cursor.fetchone()[0]
+        total_rows = self._query_with_retry(f"SELECT COUNT(*) FROM {q_old}")[0][0]
 
         if total_rows > 0:
             # Seed: fetch the first PK value (MIN() doesn't support UUID).
-            with self.connection.cursor() as cursor:
-                cursor.execute(f"SELECT {q_pk} FROM {q_old} ORDER BY {q_pk} LIMIT 1")
-                last_pk = cursor.fetchone()[0]
+            last_pk = self._query_with_retry(f"SELECT {q_pk} FROM {q_old} ORDER BY {q_pk} LIMIT 1")[0][0]
 
             copied = 0
             while copied < total_rows:
@@ -450,21 +459,17 @@ class DatabaseSchemaEditor(schema.DatabaseSchemaEditor):
                     [last_pk],
                 )
                 # Advance the cursor past the batch we just copied.
-                with self.connection.cursor() as cursor:
-                    cursor.execute(
-                        f"SELECT {q_pk} FROM {q_old} WHERE {q_pk} >= %s ORDER BY {q_pk} LIMIT 1 OFFSET {_COPY_BATCH_SIZE}",
-                        [last_pk],
-                    )
-                    row = cursor.fetchone()
-                if row is None:
+                rows = self._query_with_retry(
+                    f"SELECT {q_pk} FROM {q_old} WHERE {q_pk} >= %s ORDER BY {q_pk} LIMIT 1 OFFSET {_COPY_BATCH_SIZE}",
+                    [last_pk],
+                )
+                if not rows:
                     break  # No more rows
-                last_pk = row[0]
+                last_pk = rows[0][0]
                 copied += _COPY_BATCH_SIZE
 
             # Verify the copy is complete before dropping the source.
-            with self.connection.cursor() as cursor:
-                cursor.execute(f"SELECT COUNT(*) FROM {q_new}")
-                copied_rows = cursor.fetchone()[0]
+            copied_rows = self._query_with_retry(f"SELECT COUNT(*) FROM {q_new}")[0][0]
             if copied_rows != total_rows:
                 # Abort: recover by renaming old__ back to original.
                 self.execute(f"DROP TABLE IF EXISTS {q_new}")

--- a/python/django/aurora_dsql_django/schema.py
+++ b/python/django/aurora_dsql_django/schema.py
@@ -65,6 +65,13 @@ class DatabaseSchemaEditor(schema.DatabaseSchemaEditor):
         self.connection.ensure_connection()
         return self
 
+    @staticmethod
+    def _is_occ_error(exc):
+        """Check whether an OperationalError is a DSQL OCC conflict (OC000/OC001)."""
+        if hasattr(exc, "__cause__") and hasattr(exc.__cause__, "sqlstate"):
+            return exc.__cause__.sqlstate in ("OC000", "OC001")
+        return False
+
     def execute(self, sql, params=()):
         """
         Execute SQL with automatic retry on DSQL OCC errors.
@@ -76,11 +83,12 @@ class DatabaseSchemaEditor(schema.DatabaseSchemaEditor):
         for attempt in range(_OCC_MAX_RETRIES):
             try:
                 return super().execute(sql, params)
-            except OperationalError:
-                if attempt == _OCC_MAX_RETRIES - 1:
+            except OperationalError as e:
+                if not self._is_occ_error(e) or attempt == _OCC_MAX_RETRIES - 1:
                     raise
                 logger.debug(
-                    "DSQL OCC error on attempt %d/%d, retrying in %.1fs",
+                    "DSQL OCC error (sqlstate=%s) on attempt %d/%d, retrying in %.1fs",
+                    e.__cause__.sqlstate,
                     attempt + 1,
                     _OCC_MAX_RETRIES,
                     _OCC_RETRY_DELAY,
@@ -124,7 +132,7 @@ class DatabaseSchemaEditor(schema.DatabaseSchemaEditor):
 
     def _create_like_index_sql(self, model, field):
         # Aurora DSQL doesn't support LIKE indexes which use postgres
-        # opsclasses
+        # opclasses
         return None
 
     # -------------------------------------------------------------------------
@@ -281,6 +289,12 @@ class DatabaseSchemaEditor(schema.DatabaseSchemaEditor):
             indexes = [index for index in indexes if delete_field.name not in index.fields]
 
         constraints = list(model._meta.constraints)
+        if delete_field:
+            constraints = [
+                constraint
+                for constraint in constraints
+                if not (hasattr(constraint, "fields") and delete_field.name in constraint.fields)
+            ]
 
         # Construct a model with the new__<table> name for creating the new schema.
         # Use deep copies so the existing model's internals aren't modified.
@@ -301,6 +315,18 @@ class DatabaseSchemaEditor(schema.DatabaseSchemaEditor):
         original_table = model._meta.db_table
         old_table = f"old__{strip_quotes(original_table)}"
         new_table = new_model._meta.db_table
+        remake_tables = (original_table, old_table, new_table)
+
+        def _clear_deferred_sql_for_remake():
+            """Remove deferred SQL referencing any of the three remake tables."""
+            self.deferred_sql = [
+                sql
+                for sql in self.deferred_sql
+                if not (
+                    isinstance(sql, Statement)
+                    and any(sql.references_table(t) for t in remake_tables)
+                )
+            ]
 
         # Step 0: Recover from a previous failed _remake_table.
         #
@@ -321,9 +347,7 @@ class DatabaseSchemaEditor(schema.DatabaseSchemaEditor):
                     original_table,
                 )
                 self.execute(f"ALTER TABLE {self.quote_name(new_table)} RENAME TO {self.quote_name(original_table)}")
-                # Clean up deferred SQL from the partial run, then fall
-                # through to redo the full _remake_table from scratch.
-                self.deferred_sql = []
+                _clear_deferred_sql_for_remake()
             elif old_exists:
                 # Failed after RENAME original → old__ but before completing.
                 # old__table has the data. Rename it back to the original.
@@ -335,7 +359,7 @@ class DatabaseSchemaEditor(schema.DatabaseSchemaEditor):
                 )
                 self.execute(f"DROP TABLE IF EXISTS {self.quote_name(new_table)}")
                 self.execute(f"ALTER TABLE {self.quote_name(old_table)} RENAME TO {self.quote_name(original_table)}")
-                self.deferred_sql = []
+                _clear_deferred_sql_for_remake()
             else:
                 raise RuntimeError(
                     f"Cannot recover _remake_table for '{original_table}': "
@@ -366,10 +390,9 @@ class DatabaseSchemaEditor(schema.DatabaseSchemaEditor):
         self.create_model(new_model)
 
         # Step 3: Copy data from the frozen old table into the new table.
-        # DSQL has a 3000 row limit per transaction. Copy in batches to
-        # stay within the limit. Each batch auto-commits independently
-        # (can_rollback_ddl = False). ORDER BY the primary key guarantees
-        # deterministic, non-overlapping slices across batches.
+        # DSQL has a 3000 row limit per transaction. Copy in batches using
+        # cursor-based pagination (WHERE pk >= last_pk) for O(n) performance.
+        # Each batch auto-commits independently (can_rollback_ddl = False).
         dst_cols = ", ".join(self.quote_name(x) for x in mapping)
         src_exprs = ", ".join(mapping.values())
         q_new = self.quote_name(new_table)
@@ -380,16 +403,38 @@ class DatabaseSchemaEditor(schema.DatabaseSchemaEditor):
             cursor.execute(f"SELECT COUNT(*) FROM {q_old}")
             total_rows = cursor.fetchone()[0]
 
-        for offset in range(0, total_rows, _COPY_BATCH_SIZE):
-            self.execute(
-                f"INSERT INTO {q_new} ({dst_cols})"
-                f" SELECT {src_exprs} FROM {q_old}"
-                f" ORDER BY {q_pk}"
-                f" LIMIT {_COPY_BATCH_SIZE} OFFSET {offset}"
-            )
-
-        # Verify the copy is complete before dropping the source.
         if total_rows > 0:
+            # Seed: fetch the minimum PK to start from
+            with self.connection.cursor() as cursor:
+                cursor.execute(f"SELECT MIN({q_pk}) FROM {q_old}")
+                last_pk = cursor.fetchone()[0]
+
+            copied = 0
+            while copied < total_rows:
+                self.execute(
+                    f"INSERT INTO {q_new} ({dst_cols})"
+                    f" SELECT {src_exprs} FROM {q_old}"
+                    f" WHERE {q_pk} >= %s"
+                    f" ORDER BY {q_pk}"
+                    f" LIMIT {_COPY_BATCH_SIZE}",
+                    [last_pk],
+                )
+                # Advance the cursor past the batch we just copied.
+                with self.connection.cursor() as cursor:
+                    cursor.execute(
+                        f"SELECT {q_pk} FROM {q_old}"
+                        f" WHERE {q_pk} >= %s"
+                        f" ORDER BY {q_pk}"
+                        f" LIMIT 1 OFFSET {_COPY_BATCH_SIZE}",
+                        [last_pk],
+                    )
+                    row = cursor.fetchone()
+                if row is None:
+                    break  # No more rows
+                last_pk = row[0]
+                copied += _COPY_BATCH_SIZE
+
+            # Verify the copy is complete before dropping the source.
             with self.connection.cursor() as cursor:
                 cursor.execute(f"SELECT COUNT(*) FROM {q_new}")
                 copied_rows = cursor.fetchone()[0]
@@ -440,7 +485,10 @@ class DatabaseSchemaEditor(schema.DatabaseSchemaEditor):
         renames; otherwise recreate the table.
         """
         # Use "ALTER TABLE ... RENAME COLUMN" if only the column name changed.
-        if old_field.column != new_field.column and self.column_sql(model, old_field) == self.column_sql(model, new_field):
+        if (
+            old_field.column != new_field.column
+            and self.column_sql(model, old_field) == self.column_sql(model, new_field)
+        ):
             return self.execute(self._rename_field_sql(model._meta.db_table, old_field, new_field, new_type))
         # Everything else: recreate the table.
         self._remake_table(model, alter_fields=[(old_field, new_field)])

--- a/python/django/aurora_dsql_django/schema.py
+++ b/python/django/aurora_dsql_django/schema.py
@@ -322,10 +322,7 @@ class DatabaseSchemaEditor(schema.DatabaseSchemaEditor):
             self.deferred_sql = [
                 sql
                 for sql in self.deferred_sql
-                if not (
-                    isinstance(sql, Statement)
-                    and any(sql.references_table(t) for t in remake_tables)
-                )
+                if not (isinstance(sql, Statement) and any(sql.references_table(t) for t in remake_tables))
             ]
 
         # Step 0: Recover from a previous failed _remake_table.
@@ -404,9 +401,9 @@ class DatabaseSchemaEditor(schema.DatabaseSchemaEditor):
             total_rows = cursor.fetchone()[0]
 
         if total_rows > 0:
-            # Seed: fetch the minimum PK to start from
+            # Seed: fetch the first PK value (MIN() doesn't support UUID).
             with self.connection.cursor() as cursor:
-                cursor.execute(f"SELECT MIN({q_pk}) FROM {q_old}")
+                cursor.execute(f"SELECT {q_pk} FROM {q_old} ORDER BY {q_pk} LIMIT 1")
                 last_pk = cursor.fetchone()[0]
 
             copied = 0
@@ -422,10 +419,7 @@ class DatabaseSchemaEditor(schema.DatabaseSchemaEditor):
                 # Advance the cursor past the batch we just copied.
                 with self.connection.cursor() as cursor:
                     cursor.execute(
-                        f"SELECT {q_pk} FROM {q_old}"
-                        f" WHERE {q_pk} >= %s"
-                        f" ORDER BY {q_pk}"
-                        f" LIMIT 1 OFFSET {_COPY_BATCH_SIZE}",
+                        f"SELECT {q_pk} FROM {q_old} WHERE {q_pk} >= %s ORDER BY {q_pk} LIMIT 1 OFFSET {_COPY_BATCH_SIZE}",
                         [last_pk],
                     )
                     row = cursor.fetchone()
@@ -485,10 +479,7 @@ class DatabaseSchemaEditor(schema.DatabaseSchemaEditor):
         renames; otherwise recreate the table.
         """
         # Use "ALTER TABLE ... RENAME COLUMN" if only the column name changed.
-        if (
-            old_field.column != new_field.column
-            and self.column_sql(model, old_field) == self.column_sql(model, new_field)
-        ):
+        if old_field.column != new_field.column and self.column_sql(model, old_field) == self.column_sql(model, new_field):
             return self.execute(self._rename_field_sql(model._meta.db_table, old_field, new_field, new_type))
         # Everything else: recreate the table.
         self._remake_table(model, alter_fields=[(old_field, new_field)])

--- a/python/django/aurora_dsql_django/schema.py
+++ b/python/django/aurora_dsql_django/schema.py
@@ -156,10 +156,16 @@ class DatabaseSchemaEditor(schema.DatabaseSchemaEditor):
     # one-DDL-per-transaction rule without any special transaction handling.
     # OCC errors (OC000/OC001) are retried automatically via execute().
     #
+    # Data safety: the source table (old__) is kept until the copy is
+    # verified by row count. Any failure before that point recovers from
+    # old__. After verification, old__ is dropped and any subsequent
+    # failure recovers from new__. No path loses data silently.
+    #
     # WARNING: This is designed for development iteration, not production
-    # use on tables with significant data. The table is unavailable during
-    # the recreation window, and the batched copy holds no cross-batch
-    # transactional guarantee.
+    # use on tables with significant data. The table is unavailable under
+    # its original name during the recreation window (between steps 1
+    # and 5). For production schema changes, consider blue/green
+    # deployments or manual migration strategies.
     # -------------------------------------------------------------------------
 
     def _table_exists(self, table_name):
@@ -202,8 +208,7 @@ class DatabaseSchemaEditor(schema.DatabaseSchemaEditor):
             This is designed for **development and iteration**, not
             production use on tables with significant data. The table is
             unavailable under its original name during the recreation
-            window, and the batched copy holds no cross-batch transactional
-            guarantee. For production schema changes, consider blue/green
+            window. For production schema changes, consider blue/green
             deployments or manual migration strategies.
         """
         # Work out the new fields dict / mapping
@@ -277,26 +282,8 @@ class DatabaseSchemaEditor(schema.DatabaseSchemaEditor):
 
         constraints = list(model._meta.constraints)
 
-        # Provide isolated instances of the fields to the new model body so
-        # that the existing model's internals aren't interfered with when
-        # the dummy model is constructed.
-        body_copy = copy.deepcopy(body)
-
-        # Construct a new model for FK resolution (never materialized as a table).
-        meta_contents = {
-            "app_label": model._meta.app_label,
-            "db_table": model._meta.db_table,
-            "unique_together": unique_together,
-            "indexes": indexes,
-            "constraints": constraints,
-            "apps": apps,
-        }
-        meta = type("Meta", (), meta_contents)
-        body_copy["Meta"] = meta
-        body_copy["__module__"] = model.__module__
-        type(model._meta.object_name, model.__bases__, body_copy)
-
         # Construct a model with the new__<table> name for creating the new schema.
+        # Use deep copies so the existing model's internals aren't modified.
         body_copy = copy.deepcopy(body)
         meta_contents = {
             "app_label": model._meta.app_label,
@@ -385,31 +372,31 @@ class DatabaseSchemaEditor(schema.DatabaseSchemaEditor):
         # deterministic, non-overlapping slices across batches.
         dst_cols = ", ".join(self.quote_name(x) for x in mapping)
         src_exprs = ", ".join(mapping.values())
-        dst_table = self.quote_name(new_model._meta.db_table)
-        src_table = self.quote_name(old_table)
-        order_by = self.quote_name(model._meta.pk.column)
+        q_new = self.quote_name(new_table)
+        q_old = self.quote_name(old_table)
+        q_pk = self.quote_name(model._meta.pk.column)
 
         with self.connection.cursor() as cursor:
-            cursor.execute(f"SELECT COUNT(*) FROM {src_table}")
+            cursor.execute(f"SELECT COUNT(*) FROM {q_old}")
             total_rows = cursor.fetchone()[0]
 
         for offset in range(0, total_rows, _COPY_BATCH_SIZE):
             self.execute(
-                f"INSERT INTO {dst_table} ({dst_cols})"
-                f" SELECT {src_exprs} FROM {src_table}"
-                f" ORDER BY {order_by}"
+                f"INSERT INTO {q_new} ({dst_cols})"
+                f" SELECT {src_exprs} FROM {q_old}"
+                f" ORDER BY {q_pk}"
                 f" LIMIT {_COPY_BATCH_SIZE} OFFSET {offset}"
             )
 
         # Verify the copy is complete before dropping the source.
         if total_rows > 0:
             with self.connection.cursor() as cursor:
-                cursor.execute(f"SELECT COUNT(*) FROM {dst_table}")
+                cursor.execute(f"SELECT COUNT(*) FROM {q_new}")
                 copied_rows = cursor.fetchone()[0]
             if copied_rows != total_rows:
                 # Abort: recover by renaming old__ back to original.
-                self.execute(f"DROP TABLE IF EXISTS {dst_table}")
-                self.execute(f"ALTER TABLE {self.quote_name(old_table)} RENAME TO {self.quote_name(original_table)}")
+                self.execute(f"DROP TABLE IF EXISTS {q_new}")
+                self.execute(f"ALTER TABLE {q_old} RENAME TO {self.quote_name(original_table)}")
                 raise RuntimeError(
                     f"_remake_table copy verification failed for "
                     f"'{original_table}': expected {total_rows} rows, "

--- a/python/django/aurora_dsql_django/tests/integration/conftest.py
+++ b/python/django/aurora_dsql_django/tests/integration/conftest.py
@@ -2,8 +2,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import django
-from django.conf import settings
 
 # Ensure Django app registry is ready before tests that create dynamic models.
-if settings.configured and not django.apps.apps.ready:
-    django.setup()
+django.setup()

--- a/python/django/aurora_dsql_django/tests/integration/conftest.py
+++ b/python/django/aurora_dsql_django/tests/integration/conftest.py
@@ -1,0 +1,9 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+import django
+from django.conf import settings
+
+# Ensure Django app registry is ready before tests that create dynamic models.
+if settings.configured and not django.apps.apps.ready:
+    django.setup()

--- a/python/django/aurora_dsql_django/tests/integration/test_contrib_migrations.py
+++ b/python/django/aurora_dsql_django/tests/integration/test_contrib_migrations.py
@@ -13,7 +13,7 @@ import time
 import unittest
 
 from django.core.management import call_command
-from django.db import connection, OperationalError
+from django.db import OperationalError, connection
 
 
 def _drop_tables_with_retry(tables, max_retries=3, delay=1.0):
@@ -27,9 +27,7 @@ def _drop_tables_with_retry(tables, max_retries=3, delay=1.0):
         for attempt in range(max_retries):
             try:
                 with connection.cursor() as cursor:
-                    cursor.execute(
-                        f"DROP TABLE IF EXISTS {connection.ops.quote_name(table)}"
-                    )
+                    cursor.execute(f"DROP TABLE IF EXISTS {connection.ops.quote_name(table)}")
                 break
             except OperationalError:
                 if attempt == max_retries - 1:

--- a/python/django/aurora_dsql_django/tests/integration/test_contrib_migrations.py
+++ b/python/django/aurora_dsql_django/tests/integration/test_contrib_migrations.py
@@ -9,20 +9,19 @@ against a real DSQL cluster. These migrations exercise ALTER COLUMN, DROP COLUMN
 and ADD COLUMN operations that require the adapter's table recreation support.
 """
 
+import unittest
+
 from django.core.management import call_command
 from django.db import connection
-from django.test import TransactionTestCase
 
 
-class TestContribMigrations(TransactionTestCase):
+class TestContribMigrations(unittest.TestCase):
     """
     Run Django's contrib migrations against a real DSQL cluster.
 
     Verifies that all default Django contrib app migrations complete
     successfully and produce the expected schema.
     """
-
-    databases = {"default"}
 
     @classmethod
     def setUpClass(cls):

--- a/python/django/aurora_dsql_django/tests/integration/test_contrib_migrations.py
+++ b/python/django/aurora_dsql_django/tests/integration/test_contrib_migrations.py
@@ -13,7 +13,44 @@ import time
 import unittest
 
 from django.core.management import call_command
-from django.db import connection
+from django.db import connection, OperationalError
+
+
+def _drop_tables_with_retry(tables, max_retries=3, delay=1.0):
+    """
+    Drop tables one by one, retrying on DSQL OCC errors.
+
+    DSQL may return SerializationFailure (OC000/OC001) when schema changes
+    conflict. Each DROP is retried independently with a fresh connection.
+    """
+    for table in tables:
+        for attempt in range(max_retries):
+            try:
+                with connection.cursor() as cursor:
+                    cursor.execute(
+                        f"DROP TABLE IF EXISTS {connection.ops.quote_name(table)}"
+                    )
+                break
+            except OperationalError:
+                if attempt == max_retries - 1:
+                    break  # Best-effort cleanup -- don't fail teardown
+                connection.close()
+                time.sleep(delay)
+
+
+# All tables that Django contrib migrations create, in dependency order.
+_DJANGO_TABLES = [
+    "django_admin_log",
+    "auth_user_user_permissions",
+    "auth_user_groups",
+    "auth_permission",
+    "auth_group_permissions",
+    "auth_group",
+    "auth_user",
+    "django_content_type",
+    "django_session",
+    "django_migrations",
+]
 
 
 class TestContribMigrations(unittest.TestCase):
@@ -29,32 +66,15 @@ class TestContribMigrations(unittest.TestCase):
         """Drop all Django tables to start from a clean state."""
         super().setUpClass()
         connection.close()
-        cls._clean_database()
-
-    @classmethod
-    def _clean_database(cls):
-        """Drop all tables that Django migrations would create."""
-        tables_to_drop = [
-            "django_admin_log",
-            "auth_user_user_permissions",
-            "auth_user_groups",
-            "auth_permission",
-            "auth_group_permissions",
-            "auth_group",
-            "auth_user",
-            "django_content_type",
-            "django_session",
-            "django_migrations",
-        ]
-        with connection.cursor() as cursor:
-            for table in tables_to_drop:
-                cursor.execute(f"DROP TABLE IF EXISTS {connection.ops.quote_name(table)}")
+        _drop_tables_with_retry(_DJANGO_TABLES)
+        # Let schema changes propagate before running migrations.
+        time.sleep(2)
 
     @classmethod
     def tearDownClass(cls):
         """Clean up all tables created by migrations."""
         connection.close()
-        cls._clean_database()
+        _drop_tables_with_retry(_DJANGO_TABLES)
         super().tearDownClass()
 
     def test_migrate_contenttypes_and_auth(self):
@@ -66,20 +86,26 @@ class TestContribMigrations(unittest.TestCase):
           - auth.0002-0012: AlterField (varchar length, nullability changes)
         """
         # Run migrate -- this will apply all migrations for INSTALLED_APPS.
-        # DSQL may throw OC001 if schema changes from _clean_database haven't
-        # fully propagated. Retry with a fresh connection as recommended.
+        # DSQL may throw OCC errors (OC000/OC001) if schema changes haven't
+        # fully propagated. Retry with a fresh connection.
         last_error = None
         for attempt in range(3):
             try:
+                connection.close()
                 call_command("migrate", verbosity=1, no_color=True)
                 last_error = None
                 break
+            except OperationalError as e:
+                last_error = e
+                if attempt < 2:
+                    connection.close()
+                    # Clean up partial migration state before retrying.
+                    _drop_tables_with_retry(_DJANGO_TABLES)
+                    time.sleep(3)
+                    continue
+                break
             except Exception as e:
                 last_error = e
-                if "OC001" in str(e) and attempt < 2:
-                    connection.close()
-                    time.sleep(2)
-                    continue
                 break
         if last_error is not None:
             self.fail(f"Django migrate failed: {last_error}")

--- a/python/django/aurora_dsql_django/tests/integration/test_contrib_migrations.py
+++ b/python/django/aurora_dsql_django/tests/integration/test_contrib_migrations.py
@@ -92,7 +92,7 @@ class TestContribMigrations(unittest.TestCase):
         # DSQL may throw OCC errors (OC000/OC001) if schema changes haven't
         # fully propagated. Retry with a fresh connection.
         last_error = None
-        max_retries = 5
+        max_retries = 8
         for attempt in range(max_retries):
             try:
                 connection.close()
@@ -105,7 +105,8 @@ class TestContribMigrations(unittest.TestCase):
                     connection.close()
                     # Clean up partial migration state before retrying.
                     _drop_tables_with_retry(_DJANGO_TABLES)
-                    time.sleep(5)
+                    # Exponential backoff: 5, 10, 15, ... seconds.
+                    time.sleep(5 * (attempt + 1))
                     continue
                 break
             except Exception as e:

--- a/python/django/aurora_dsql_django/tests/integration/test_contrib_migrations.py
+++ b/python/django/aurora_dsql_django/tests/integration/test_contrib_migrations.py
@@ -11,10 +11,10 @@ and ADD COLUMN operations that require the adapter's table recreation support.
 
 from django.core.management import call_command
 from django.db import connection
-from django.test import TestCase
+from django.test import TransactionTestCase
 
 
-class TestContribMigrations(TestCase):
+class TestContribMigrations(TransactionTestCase):
     """
     Run Django's contrib migrations against a real DSQL cluster.
 

--- a/python/django/aurora_dsql_django/tests/integration/test_contrib_migrations.py
+++ b/python/django/aurora_dsql_django/tests/integration/test_contrib_migrations.py
@@ -27,6 +27,7 @@ class TestContribMigrations(unittest.TestCase):
     def setUpClass(cls):
         """Drop all Django tables to start from a clean state."""
         super().setUpClass()
+        connection.close()
         cls._clean_database()
 
     @classmethod
@@ -46,13 +47,12 @@ class TestContribMigrations(unittest.TestCase):
         ]
         with connection.cursor() as cursor:
             for table in tables_to_drop:
-                cursor.execute("BEGIN")
                 cursor.execute(f"DROP TABLE IF EXISTS {connection.ops.quote_name(table)}")
-                cursor.execute("COMMIT")
 
     @classmethod
     def tearDownClass(cls):
         """Clean up all tables created by migrations."""
+        connection.close()
         cls._clean_database()
         super().tearDownClass()
 
@@ -64,7 +64,7 @@ class TestContribMigrations(unittest.TestCase):
           - contenttypes.0002: AlterField (nullability) + RemoveField
           - auth.0002-0012: AlterField (varchar length, nullability changes)
         """
-        # Run migrate — this will apply all migrations for INSTALLED_APPS
+        # Run migrate -- this will apply all migrations for INSTALLED_APPS
         # (django.contrib.contenttypes and django.contrib.auth per test_settings.py)
         try:
             call_command("migrate", verbosity=1, no_color=True)
@@ -87,7 +87,7 @@ class TestContribMigrations(unittest.TestCase):
             self.assertNotIn("name", ct_columns, "contenttypes.0002 should remove the 'name' column")
 
             # auth_user should exist with the final column sizes
-            # (auth.0008 changes username max_length 30→150, etc.)
+            # (auth.0008 changes username max_length 30->150, etc.)
             cursor.execute(
                 "SELECT column_name, character_maximum_length "
                 "FROM information_schema.columns "
@@ -108,7 +108,7 @@ class TestContribMigrations(unittest.TestCase):
             self.assertEqual(row[0], "YES", "last_login should be nullable after auth.0005")
 
             # auth_permission.name should have max_length 255
-            # (auth.0002 changes it from 50→255)
+            # (auth.0002 changes it from 50->255)
             cursor.execute(
                 "SELECT character_maximum_length "
                 "FROM information_schema.columns "

--- a/python/django/aurora_dsql_django/tests/integration/test_contrib_migrations.py
+++ b/python/django/aurora_dsql_django/tests/integration/test_contrib_migrations.py
@@ -92,7 +92,8 @@ class TestContribMigrations(unittest.TestCase):
         # DSQL may throw OCC errors (OC000/OC001) if schema changes haven't
         # fully propagated. Retry with a fresh connection.
         last_error = None
-        for attempt in range(3):
+        max_retries = 5
+        for attempt in range(max_retries):
             try:
                 connection.close()
                 call_command("migrate", verbosity=1, no_color=True)
@@ -100,11 +101,11 @@ class TestContribMigrations(unittest.TestCase):
                 break
             except OperationalError as e:
                 last_error = e
-                if attempt < 2:
+                if attempt < max_retries - 1:
                     connection.close()
                     # Clean up partial migration state before retrying.
                     _drop_tables_with_retry(_DJANGO_TABLES)
-                    time.sleep(3)
+                    time.sleep(5)
                     continue
                 break
             except Exception as e:

--- a/python/django/aurora_dsql_django/tests/integration/test_contrib_migrations.py
+++ b/python/django/aurora_dsql_django/tests/integration/test_contrib_migrations.py
@@ -9,6 +9,7 @@ against a real DSQL cluster. These migrations exercise ALTER COLUMN, DROP COLUMN
 and ADD COLUMN operations that require the adapter's table recreation support.
 """
 
+import time
 import unittest
 
 from django.core.management import call_command
@@ -64,12 +65,24 @@ class TestContribMigrations(unittest.TestCase):
           - contenttypes.0002: AlterField (nullability) + RemoveField
           - auth.0002-0012: AlterField (varchar length, nullability changes)
         """
-        # Run migrate -- this will apply all migrations for INSTALLED_APPS
-        # (django.contrib.contenttypes and django.contrib.auth per test_settings.py)
-        try:
-            call_command("migrate", verbosity=1, no_color=True)
-        except Exception as e:
-            self.fail(f"Django migrate failed: {e}")
+        # Run migrate -- this will apply all migrations for INSTALLED_APPS.
+        # DSQL may throw OC001 if schema changes from _clean_database haven't
+        # fully propagated. Retry with a fresh connection as recommended.
+        last_error = None
+        for attempt in range(3):
+            try:
+                call_command("migrate", verbosity=1, no_color=True)
+                last_error = None
+                break
+            except Exception as e:
+                last_error = e
+                if "OC001" in str(e) and attempt < 2:
+                    connection.close()
+                    time.sleep(2)
+                    continue
+                break
+        if last_error is not None:
+            self.fail(f"Django migrate failed: {last_error}")
 
         # Verify the key tables exist with the correct final schema
         with connection.cursor() as cursor:

--- a/python/django/aurora_dsql_django/tests/integration/test_contrib_migrations.py
+++ b/python/django/aurora_dsql_django/tests/integration/test_contrib_migrations.py
@@ -1,0 +1,131 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Integration test for Django contrib app migrations.
+
+Runs the full migration sequence for auth, contenttypes, admin, and sessions
+against a real DSQL cluster. These migrations exercise ALTER COLUMN, DROP COLUMN,
+and ADD COLUMN operations that require the adapter's table recreation support.
+"""
+
+from django.core.management import call_command
+from django.db import connection
+from django.test import TestCase
+
+
+class TestContribMigrations(TestCase):
+    """
+    Run Django's contrib migrations against a real DSQL cluster.
+
+    Verifies that all default Django contrib app migrations complete
+    successfully and produce the expected schema.
+    """
+
+    databases = {"default"}
+
+    @classmethod
+    def setUpClass(cls):
+        """Drop all Django tables to start from a clean state."""
+        super().setUpClass()
+        cls._clean_database()
+
+    @classmethod
+    def _clean_database(cls):
+        """Drop all tables that Django migrations would create."""
+        tables_to_drop = [
+            "django_admin_log",
+            "auth_user_user_permissions",
+            "auth_user_groups",
+            "auth_permission",
+            "auth_group_permissions",
+            "auth_group",
+            "auth_user",
+            "django_content_type",
+            "django_session",
+            "django_migrations",
+        ]
+        with connection.cursor() as cursor:
+            for table in tables_to_drop:
+                cursor.execute("BEGIN")
+                cursor.execute(f"DROP TABLE IF EXISTS {connection.ops.quote_name(table)}")
+                cursor.execute("COMMIT")
+
+    @classmethod
+    def tearDownClass(cls):
+        """Clean up all tables created by migrations."""
+        cls._clean_database()
+        super().tearDownClass()
+
+    def test_migrate_contenttypes_and_auth(self):
+        """
+        Run all contenttypes and auth migrations and verify the final schema.
+
+        Key operations covered:
+          - contenttypes.0002: AlterField (nullability) + RemoveField
+          - auth.0002-0012: AlterField (varchar length, nullability changes)
+        """
+        # Run migrate — this will apply all migrations for INSTALLED_APPS
+        # (django.contrib.contenttypes and django.contrib.auth per test_settings.py)
+        try:
+            call_command("migrate", verbosity=1, no_color=True)
+        except Exception as e:
+            self.fail(f"Django migrate failed: {e}")
+
+        # Verify the key tables exist with the correct final schema
+        with connection.cursor() as cursor:
+            # django_content_type should exist WITHOUT the 'name' column
+            # (contenttypes.0002 removes it via AlterField + RemoveField)
+            cursor.execute(
+                "SELECT column_name FROM information_schema.columns "
+                "WHERE table_name = 'django_content_type' "
+                "ORDER BY ordinal_position"
+            )
+            ct_columns = [row[0] for row in cursor.fetchall()]
+            self.assertIn("id", ct_columns)
+            self.assertIn("app_label", ct_columns)
+            self.assertIn("model", ct_columns)
+            self.assertNotIn("name", ct_columns, "contenttypes.0002 should remove the 'name' column")
+
+            # auth_user should exist with the final column sizes
+            # (auth.0008 changes username max_length 30→150, etc.)
+            cursor.execute(
+                "SELECT column_name, character_maximum_length "
+                "FROM information_schema.columns "
+                "WHERE table_name = 'auth_user' AND column_name = 'username'"
+            )
+            row = cursor.fetchone()
+            self.assertIsNotNone(row, "auth_user.username column should exist")
+            self.assertEqual(row[1], 150, "username max_length should be 150 after auth.0008")
+
+            # auth_user.last_login should be nullable
+            # (auth.0005 changes it from NOT NULL to NULL)
+            cursor.execute(
+                "SELECT is_nullable FROM information_schema.columns "
+                "WHERE table_name = 'auth_user' AND column_name = 'last_login'"
+            )
+            row = cursor.fetchone()
+            self.assertIsNotNone(row, "auth_user.last_login column should exist")
+            self.assertEqual(row[0], "YES", "last_login should be nullable after auth.0005")
+
+            # auth_permission.name should have max_length 255
+            # (auth.0002 changes it from 50→255)
+            cursor.execute(
+                "SELECT character_maximum_length "
+                "FROM information_schema.columns "
+                "WHERE table_name = 'auth_permission' AND column_name = 'name'"
+            )
+            row = cursor.fetchone()
+            self.assertIsNotNone(row, "auth_permission.name column should exist")
+            self.assertEqual(row[0], 255, "permission name max_length should be 255 after auth.0002")
+
+        # Verify migrations are recorded
+        with connection.cursor() as cursor:
+            cursor.execute("SELECT app, name FROM django_migrations WHERE app IN ('contenttypes', 'auth') ORDER BY app, name")
+            applied = {(row[0], row[1]) for row in cursor.fetchall()}
+
+            # The critical migrations that previously failed
+            self.assertIn(("contenttypes", "0002_remove_content_type_name"), applied)
+            self.assertIn(("auth", "0002_alter_permission_name_max_length"), applied)
+            self.assertIn(("auth", "0005_alter_user_last_login_null"), applied)
+            self.assertIn(("auth", "0008_alter_user_username_max_length"), applied)

--- a/python/django/aurora_dsql_django/tests/integration/test_contrib_migrations.py
+++ b/python/django/aurora_dsql_django/tests/integration/test_contrib_migrations.py
@@ -50,6 +50,11 @@ _DJANGO_TABLES = [
     "django_migrations",
 ]
 
+# Temp tables that _remake_table may leave behind on failure.
+_TEMP_TABLES = []
+for _t in _DJANGO_TABLES:
+    _TEMP_TABLES.extend([f"old__{_t}", f"new__{_t}"])
+
 
 class TestContribMigrations(unittest.TestCase):
     """
@@ -64,7 +69,7 @@ class TestContribMigrations(unittest.TestCase):
         """Drop all Django tables to start from a clean state."""
         super().setUpClass()
         connection.close()
-        _drop_tables_with_retry(_DJANGO_TABLES)
+        _drop_tables_with_retry(_TEMP_TABLES + _DJANGO_TABLES)
         # Let schema changes propagate before running migrations.
         time.sleep(2)
 
@@ -72,7 +77,7 @@ class TestContribMigrations(unittest.TestCase):
     def tearDownClass(cls):
         """Clean up all tables created by migrations."""
         connection.close()
-        _drop_tables_with_retry(_DJANGO_TABLES)
+        _drop_tables_with_retry(_TEMP_TABLES + _DJANGO_TABLES)
         super().tearDownClass()
 
     def test_migrate_contenttypes_and_auth(self):

--- a/python/django/aurora_dsql_django/tests/integration/test_schema_remake.py
+++ b/python/django/aurora_dsql_django/tests/integration/test_schema_remake.py
@@ -9,8 +9,9 @@ The adapter handles these through a table recreation pattern. These tests verify
 that pattern works correctly against a real DSQL cluster.
 """
 
+import unittest
+
 from django.db import connection, models
-from django.test import TransactionTestCase
 
 
 def _drop_table_if_exists(table_name):
@@ -21,10 +22,8 @@ def _drop_table_if_exists(table_name):
         cursor.execute("COMMIT")
 
 
-class TestRemakeTableAlterField(TransactionTestCase):
+class TestRemakeTableAlterField(unittest.TestCase):
     """Test _alter_field via table recreation on a real DSQL cluster."""
-
-    databases = {"default"}
 
     def setUp(self):
         _drop_table_if_exists("test_alter_field")
@@ -166,10 +165,8 @@ class TestRemakeTableAlterField(TransactionTestCase):
             self.assertEqual(rows[0][0], "test_value")
 
 
-class TestRemakeTableRemoveField(TransactionTestCase):
+class TestRemakeTableRemoveField(unittest.TestCase):
     """Test remove_field via table recreation on a real DSQL cluster."""
-
-    databases = {"default"}
 
     def setUp(self):
         _drop_table_if_exists("test_remove_field")
@@ -258,10 +255,8 @@ class TestRemakeTableRemoveField(TransactionTestCase):
             self.assertEqual(rows[0][0], "keep_this")
 
 
-class TestRemakeTableAddField(TransactionTestCase):
+class TestRemakeTableAddField(unittest.TestCase):
     """Test add_field via table recreation on a real DSQL cluster."""
-
-    databases = {"default"}
 
     def setUp(self):
         _drop_table_if_exists("test_add_field")

--- a/python/django/aurora_dsql_django/tests/integration/test_schema_remake.py
+++ b/python/django/aurora_dsql_django/tests/integration/test_schema_remake.py
@@ -10,7 +10,7 @@ that pattern works correctly against a real DSQL cluster.
 """
 
 from django.db import connection, models
-from django.test import TestCase
+from django.test import TransactionTestCase
 
 
 def _drop_table_if_exists(table_name):
@@ -21,7 +21,7 @@ def _drop_table_if_exists(table_name):
         cursor.execute("COMMIT")
 
 
-class TestRemakeTableAlterField(TestCase):
+class TestRemakeTableAlterField(TransactionTestCase):
     """Test _alter_field via table recreation on a real DSQL cluster."""
 
     databases = {"default"}
@@ -166,7 +166,7 @@ class TestRemakeTableAlterField(TestCase):
             self.assertEqual(rows[0][0], "test_value")
 
 
-class TestRemakeTableRemoveField(TestCase):
+class TestRemakeTableRemoveField(TransactionTestCase):
     """Test remove_field via table recreation on a real DSQL cluster."""
 
     databases = {"default"}
@@ -258,7 +258,7 @@ class TestRemakeTableRemoveField(TestCase):
             self.assertEqual(rows[0][0], "keep_this")
 
 
-class TestRemakeTableAddField(TestCase):
+class TestRemakeTableAddField(TransactionTestCase):
     """Test add_field via table recreation on a real DSQL cluster."""
 
     databases = {"default"}

--- a/python/django/aurora_dsql_django/tests/integration/test_schema_remake.py
+++ b/python/django/aurora_dsql_django/tests/integration/test_schema_remake.py
@@ -1,0 +1,366 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Integration tests for ALTER COLUMN and DROP COLUMN operations via table recreation.
+
+Aurora DSQL does not support ALTER COLUMN (TYPE, SET/DROP NOT NULL) or DROP COLUMN.
+The adapter handles these through a table recreation pattern. These tests verify
+that pattern works correctly against a real DSQL cluster.
+"""
+
+from django.db import connection, models
+from django.test import TestCase
+
+
+def _drop_table_if_exists(table_name):
+    """Drop a table if it exists, ignoring errors."""
+    with connection.cursor() as cursor:
+        cursor.execute("BEGIN")
+        cursor.execute(f"DROP TABLE IF EXISTS {connection.ops.quote_name(table_name)}")
+        cursor.execute("COMMIT")
+
+
+class TestRemakeTableAlterField(TestCase):
+    """Test _alter_field via table recreation on a real DSQL cluster."""
+
+    databases = {"default"}
+
+    def setUp(self):
+        _drop_table_if_exists("test_alter_field")
+
+    def tearDown(self):
+        _drop_table_if_exists("test_alter_field")
+
+    def _create_test_table(self, fields):
+        """Create a test table using the schema editor."""
+        # Build a dynamic model class
+        meta = type(
+            "Meta",
+            (),
+            {
+                "app_label": "test",
+                "db_table": "test_alter_field",
+            },
+        )
+        attrs = {
+            "__module__": "aurora_dsql_django.tests.integration",
+            "Meta": meta,
+        }
+        attrs.update(fields)
+        Model = type("TestAlterField", (models.Model,), attrs)
+
+        with connection.schema_editor() as editor:
+            editor.create_model(Model)
+        return Model
+
+    def _get_column_info(self, table_name, column_name):
+        """Get column type and nullability from information_schema."""
+        with connection.cursor() as cursor:
+            cursor.execute(
+                "SELECT data_type, character_maximum_length, is_nullable "
+                "FROM information_schema.columns "
+                "WHERE table_name = %s AND column_name = %s",
+                [table_name, column_name],
+            )
+            return cursor.fetchone()
+
+    def _table_exists(self, table_name):
+        """Check if a table exists."""
+        with connection.cursor() as cursor:
+            cursor.execute(
+                "SELECT COUNT(*) FROM information_schema.tables WHERE table_name = %s",
+                [table_name],
+            )
+            return cursor.fetchone()[0] > 0
+
+    def _get_columns(self, table_name):
+        """Get all column names for a table."""
+        with connection.cursor() as cursor:
+            cursor.execute(
+                "SELECT column_name FROM information_schema.columns WHERE table_name = %s ORDER BY ordinal_position",
+                [table_name],
+            )
+            return [row[0] for row in cursor.fetchall()]
+
+    def test_alter_field_change_varchar_length(self):
+        """Test that varchar max_length changes work via table recreation."""
+        Model = self._create_test_table(
+            {
+                "name": models.CharField(max_length=50),
+            }
+        )
+
+        old_field = models.CharField(max_length=50)
+        old_field.set_attributes_from_name("name")
+        old_field.model = Model
+
+        new_field = models.CharField(max_length=255)
+        new_field.set_attributes_from_name("name")
+        new_field.model = Model
+
+        with connection.schema_editor() as editor:
+            editor.alter_field(Model, old_field, new_field)
+
+        info = self._get_column_info("test_alter_field", "name")
+        self.assertIsNotNone(info, "Column 'name' should exist after alter")
+        # character_maximum_length should be updated
+        self.assertEqual(info[1], 255)
+
+    def test_alter_field_set_nullable(self):
+        """Test that nullability changes work via table recreation."""
+        Model = self._create_test_table(
+            {
+                "title": models.CharField(max_length=100),
+            }
+        )
+
+        old_field = models.CharField(max_length=100)
+        old_field.set_attributes_from_name("title")
+        old_field.model = Model
+
+        new_field = models.CharField(max_length=100, null=True)
+        new_field.set_attributes_from_name("title")
+        new_field.model = Model
+
+        with connection.schema_editor() as editor:
+            editor.alter_field(Model, old_field, new_field)
+
+        info = self._get_column_info("test_alter_field", "title")
+        self.assertIsNotNone(info, "Column 'title' should exist after alter")
+        self.assertEqual(info[2], "YES")  # is_nullable
+
+    def test_alter_field_preserves_data(self):
+        """Test that existing row data survives a table recreation."""
+        Model = self._create_test_table(
+            {
+                "name": models.CharField(max_length=50),
+            }
+        )
+
+        # Insert test data
+        with connection.cursor() as cursor:
+            cursor.execute("BEGIN")
+            cursor.execute(
+                "INSERT INTO test_alter_field (name) VALUES (%s)",
+                ["test_value"],
+            )
+            cursor.execute("COMMIT")
+
+        old_field = models.CharField(max_length=50)
+        old_field.set_attributes_from_name("name")
+        old_field.model = Model
+
+        new_field = models.CharField(max_length=255)
+        new_field.set_attributes_from_name("name")
+        new_field.model = Model
+
+        with connection.schema_editor() as editor:
+            editor.alter_field(Model, old_field, new_field)
+
+        # Verify data survived
+        with connection.cursor() as cursor:
+            cursor.execute("SELECT name FROM test_alter_field")
+            rows = cursor.fetchall()
+            self.assertEqual(len(rows), 1)
+            self.assertEqual(rows[0][0], "test_value")
+
+
+class TestRemakeTableRemoveField(TestCase):
+    """Test remove_field via table recreation on a real DSQL cluster."""
+
+    databases = {"default"}
+
+    def setUp(self):
+        _drop_table_if_exists("test_remove_field")
+
+    def tearDown(self):
+        _drop_table_if_exists("test_remove_field")
+
+    def _create_test_table(self, fields):
+        meta = type(
+            "Meta",
+            (),
+            {
+                "app_label": "test",
+                "db_table": "test_remove_field",
+            },
+        )
+        attrs = {
+            "__module__": "aurora_dsql_django.tests.integration",
+            "Meta": meta,
+        }
+        attrs.update(fields)
+        Model = type("TestRemoveField", (models.Model,), attrs)
+
+        with connection.schema_editor() as editor:
+            editor.create_model(Model)
+        return Model
+
+    def _get_columns(self, table_name):
+        with connection.cursor() as cursor:
+            cursor.execute(
+                "SELECT column_name FROM information_schema.columns WHERE table_name = %s ORDER BY ordinal_position",
+                [table_name],
+            )
+            return [row[0] for row in cursor.fetchall()]
+
+    def test_remove_field(self):
+        """Test that column removal works via table recreation."""
+        Model = self._create_test_table(
+            {
+                "name": models.CharField(max_length=100, null=True),
+                "code": models.CharField(max_length=50),
+            }
+        )
+
+        field_to_remove = models.CharField(max_length=100, null=True)
+        field_to_remove.set_attributes_from_name("name")
+        field_to_remove.model = Model
+
+        with connection.schema_editor() as editor:
+            editor.remove_field(Model, field_to_remove)
+
+        columns = self._get_columns("test_remove_field")
+        self.assertNotIn("name", columns)
+        self.assertIn("code", columns)
+        self.assertIn("id", columns)
+
+    def test_remove_field_preserves_data(self):
+        """Test that remaining columns' data survives a column removal."""
+        Model = self._create_test_table(
+            {
+                "name": models.CharField(max_length=100, null=True),
+                "code": models.CharField(max_length=50),
+            }
+        )
+
+        # Insert test data
+        with connection.cursor() as cursor:
+            cursor.execute("BEGIN")
+            cursor.execute(
+                "INSERT INTO test_remove_field (name, code) VALUES (%s, %s)",
+                ["to_remove", "keep_this"],
+            )
+            cursor.execute("COMMIT")
+
+        field_to_remove = models.CharField(max_length=100, null=True)
+        field_to_remove.set_attributes_from_name("name")
+        field_to_remove.model = Model
+
+        with connection.schema_editor() as editor:
+            editor.remove_field(Model, field_to_remove)
+
+        with connection.cursor() as cursor:
+            cursor.execute("SELECT code FROM test_remove_field")
+            rows = cursor.fetchall()
+            self.assertEqual(len(rows), 1)
+            self.assertEqual(rows[0][0], "keep_this")
+
+
+class TestRemakeTableAddField(TestCase):
+    """Test add_field via table recreation on a real DSQL cluster."""
+
+    databases = {"default"}
+
+    def setUp(self):
+        _drop_table_if_exists("test_add_field")
+
+    def tearDown(self):
+        _drop_table_if_exists("test_add_field")
+
+    def _create_test_table(self, fields):
+        meta = type(
+            "Meta",
+            (),
+            {
+                "app_label": "test",
+                "db_table": "test_add_field",
+            },
+        )
+        attrs = {
+            "__module__": "aurora_dsql_django.tests.integration",
+            "Meta": meta,
+        }
+        attrs.update(fields)
+        Model = type("TestAddField", (models.Model,), attrs)
+
+        with connection.schema_editor() as editor:
+            editor.create_model(Model)
+        return Model
+
+    def _get_column_info(self, table_name, column_name):
+        with connection.cursor() as cursor:
+            cursor.execute(
+                "SELECT data_type, character_maximum_length, is_nullable "
+                "FROM information_schema.columns "
+                "WHERE table_name = %s AND column_name = %s",
+                [table_name, column_name],
+            )
+            return cursor.fetchone()
+
+    def _get_columns(self, table_name):
+        with connection.cursor() as cursor:
+            cursor.execute(
+                "SELECT column_name FROM information_schema.columns WHERE table_name = %s ORDER BY ordinal_position",
+                [table_name],
+            )
+            return [row[0] for row in cursor.fetchall()]
+
+    def test_add_not_null_field_with_default(self):
+        """Test adding a NOT NULL field with a default to an existing table.
+
+        DSQL's ADD COLUMN only supports 'column_name data_type' — no DEFAULT
+        or NOT NULL inline. This must go through table recreation.
+        """
+        Model = self._create_test_table(
+            {
+                "name": models.CharField(max_length=100),
+            }
+        )
+
+        # Insert a row before adding the field
+        with connection.cursor() as cursor:
+            cursor.execute("BEGIN")
+            cursor.execute(
+                "INSERT INTO test_add_field (name) VALUES (%s)",
+                ["existing_row"],
+            )
+            cursor.execute("COMMIT")
+
+        new_field = models.CharField(max_length=50, default="pending")
+        new_field.set_attributes_from_name("status")
+        new_field.model = Model
+
+        with connection.schema_editor() as editor:
+            editor.add_field(Model, new_field)
+
+        columns = self._get_columns("test_add_field")
+        self.assertIn("status", columns)
+
+        # Existing row should have the default value
+        with connection.cursor() as cursor:
+            cursor.execute("SELECT name, status FROM test_add_field")
+            rows = cursor.fetchall()
+            self.assertEqual(len(rows), 1)
+            self.assertEqual(rows[0][0], "existing_row")
+            self.assertEqual(rows[0][1], "pending")
+
+    def test_add_nullable_field(self):
+        """Test adding a nullable field — should use simple ADD COLUMN."""
+        Model = self._create_test_table(
+            {
+                "name": models.CharField(max_length=100),
+            }
+        )
+
+        new_field = models.CharField(max_length=200, null=True)
+        new_field.set_attributes_from_name("description")
+        new_field.model = Model
+
+        with connection.schema_editor() as editor:
+            editor.add_field(Model, new_field)
+
+        info = self._get_column_info("test_add_field", "description")
+        self.assertIsNotNone(info, "Column 'description' should exist")
+        self.assertEqual(info[2], "YES")  # is_nullable

--- a/python/django/aurora_dsql_django/tests/integration/test_schema_remake.py
+++ b/python/django/aurora_dsql_django/tests/integration/test_schema_remake.py
@@ -20,10 +20,15 @@ def _drop_table_if_exists(table_name):
         cursor.execute(f"DROP TABLE IF EXISTS {connection.ops.quote_name(table_name)}")
 
 
-class TestRemakeTableAlterField(unittest.TestCase):
-    """Test _alter_field via table recreation on a real DSQL cluster."""
+class RemakeTableTestCase(unittest.TestCase):
+    """Base class for table recreation integration tests.
 
-    TABLE = "test_alter_field"
+    Subclasses must define TABLE (the test table name) and MODEL_NAME
+    (the dynamic model class name).
+    """
+
+    TABLE = None
+    MODEL_NAME = None
 
     def setUp(self):
         connection.close()
@@ -42,7 +47,7 @@ class TestRemakeTableAlterField(unittest.TestCase):
             (),
             {
                 "app_label": "test",
-                "db_table": "test_alter_field",
+                "db_table": self.TABLE,
             },
         )
         attrs = {
@@ -50,7 +55,7 @@ class TestRemakeTableAlterField(unittest.TestCase):
             "Meta": meta,
         }
         attrs.update(fields)
-        Model = type("TestAlterField", (models.Model,), attrs)
+        Model = type(self.MODEL_NAME, (models.Model,), attrs)
 
         with connection.schema_editor() as editor:
             editor.create_model(Model)
@@ -75,6 +80,13 @@ class TestRemakeTableAlterField(unittest.TestCase):
                 [table_name],
             )
             return [row[0] for row in cursor.fetchall()]
+
+
+class TestRemakeTableAlterField(RemakeTableTestCase):
+    """Test _alter_field via table recreation on a real DSQL cluster."""
+
+    TABLE = "test_alter_field"
+    MODEL_NAME = "TestAlterField"
 
     def test_alter_field_change_varchar_length(self):
         """Test that varchar max_length changes work via table recreation."""
@@ -156,48 +168,11 @@ class TestRemakeTableAlterField(unittest.TestCase):
             self.assertEqual(rows[0][0], "test_value")
 
 
-class TestRemakeTableRemoveField(unittest.TestCase):
+class TestRemakeTableRemoveField(RemakeTableTestCase):
     """Test remove_field via table recreation on a real DSQL cluster."""
 
     TABLE = "test_remove_field"
-
-    def setUp(self):
-        connection.close()
-        for t in [self.TABLE, f"old__{self.TABLE}", f"new__{self.TABLE}"]:
-            _drop_table_if_exists(t)
-
-    def tearDown(self):
-        connection.close()
-        for t in [self.TABLE, f"old__{self.TABLE}", f"new__{self.TABLE}"]:
-            _drop_table_if_exists(t)
-
-    def _create_test_table(self, fields):
-        meta = type(
-            "Meta",
-            (),
-            {
-                "app_label": "test",
-                "db_table": "test_remove_field",
-            },
-        )
-        attrs = {
-            "__module__": "aurora_dsql_django.tests.integration",
-            "Meta": meta,
-        }
-        attrs.update(fields)
-        Model = type("TestRemoveField", (models.Model,), attrs)
-
-        with connection.schema_editor() as editor:
-            editor.create_model(Model)
-        return Model
-
-    def _get_columns(self, table_name):
-        with connection.cursor() as cursor:
-            cursor.execute(
-                "SELECT column_name FROM information_schema.columns WHERE table_name = %s ORDER BY ordinal_position",
-                [table_name],
-            )
-            return [row[0] for row in cursor.fetchall()]
+    MODEL_NAME = "TestRemoveField"
 
     def test_remove_field(self):
         """Test that column removal works via table recreation."""
@@ -250,58 +225,11 @@ class TestRemakeTableRemoveField(unittest.TestCase):
             self.assertEqual(rows[0][0], "keep_this")
 
 
-class TestRemakeTableAddField(unittest.TestCase):
+class TestRemakeTableAddField(RemakeTableTestCase):
     """Test add_field via table recreation on a real DSQL cluster."""
 
     TABLE = "test_add_field"
-
-    def setUp(self):
-        connection.close()
-        for t in [self.TABLE, f"old__{self.TABLE}", f"new__{self.TABLE}"]:
-            _drop_table_if_exists(t)
-
-    def tearDown(self):
-        connection.close()
-        for t in [self.TABLE, f"old__{self.TABLE}", f"new__{self.TABLE}"]:
-            _drop_table_if_exists(t)
-
-    def _create_test_table(self, fields):
-        meta = type(
-            "Meta",
-            (),
-            {
-                "app_label": "test",
-                "db_table": "test_add_field",
-            },
-        )
-        attrs = {
-            "__module__": "aurora_dsql_django.tests.integration",
-            "Meta": meta,
-        }
-        attrs.update(fields)
-        Model = type("TestAddField", (models.Model,), attrs)
-
-        with connection.schema_editor() as editor:
-            editor.create_model(Model)
-        return Model
-
-    def _get_column_info(self, table_name, column_name):
-        with connection.cursor() as cursor:
-            cursor.execute(
-                "SELECT data_type, character_maximum_length, is_nullable "
-                "FROM information_schema.columns "
-                "WHERE table_name = %s AND column_name = %s",
-                [table_name, column_name],
-            )
-            return cursor.fetchone()
-
-    def _get_columns(self, table_name):
-        with connection.cursor() as cursor:
-            cursor.execute(
-                "SELECT column_name FROM information_schema.columns WHERE table_name = %s ORDER BY ordinal_position",
-                [table_name],
-            )
-            return [row[0] for row in cursor.fetchall()]
+    MODEL_NAME = "TestAddField"
 
     def test_add_not_null_field_with_default(self):
         """Test adding a NOT NULL field with a default to an existing table.

--- a/python/django/aurora_dsql_django/tests/integration/test_schema_remake.py
+++ b/python/django/aurora_dsql_django/tests/integration/test_schema_remake.py
@@ -17,23 +17,22 @@ from django.db import connection, models
 def _drop_table_if_exists(table_name):
     """Drop a table if it exists, ignoring errors."""
     with connection.cursor() as cursor:
-        cursor.execute("BEGIN")
         cursor.execute(f"DROP TABLE IF EXISTS {connection.ops.quote_name(table_name)}")
-        cursor.execute("COMMIT")
 
 
 class TestRemakeTableAlterField(unittest.TestCase):
     """Test _alter_field via table recreation on a real DSQL cluster."""
 
     def setUp(self):
+        connection.close()
         _drop_table_if_exists("test_alter_field")
 
     def tearDown(self):
+        connection.close()
         _drop_table_if_exists("test_alter_field")
 
     def _create_test_table(self, fields):
         """Create a test table using the schema editor."""
-        # Build a dynamic model class
         meta = type(
             "Meta",
             (),
@@ -63,15 +62,6 @@ class TestRemakeTableAlterField(unittest.TestCase):
                 [table_name, column_name],
             )
             return cursor.fetchone()
-
-    def _table_exists(self, table_name):
-        """Check if a table exists."""
-        with connection.cursor() as cursor:
-            cursor.execute(
-                "SELECT COUNT(*) FROM information_schema.tables WHERE table_name = %s",
-                [table_name],
-            )
-            return cursor.fetchone()[0] > 0
 
     def _get_columns(self, table_name):
         """Get all column names for a table."""
@@ -103,7 +93,6 @@ class TestRemakeTableAlterField(unittest.TestCase):
 
         info = self._get_column_info("test_alter_field", "name")
         self.assertIsNotNone(info, "Column 'name' should exist after alter")
-        # character_maximum_length should be updated
         self.assertEqual(info[1], 255)
 
     def test_alter_field_set_nullable(self):
@@ -139,12 +128,10 @@ class TestRemakeTableAlterField(unittest.TestCase):
 
         # Insert test data
         with connection.cursor() as cursor:
-            cursor.execute("BEGIN")
             cursor.execute(
                 "INSERT INTO test_alter_field (name) VALUES (%s)",
                 ["test_value"],
             )
-            cursor.execute("COMMIT")
 
         old_field = models.CharField(max_length=50)
         old_field.set_attributes_from_name("name")
@@ -169,9 +156,11 @@ class TestRemakeTableRemoveField(unittest.TestCase):
     """Test remove_field via table recreation on a real DSQL cluster."""
 
     def setUp(self):
+        connection.close()
         _drop_table_if_exists("test_remove_field")
 
     def tearDown(self):
+        connection.close()
         _drop_table_if_exists("test_remove_field")
 
     def _create_test_table(self, fields):
@@ -234,12 +223,10 @@ class TestRemakeTableRemoveField(unittest.TestCase):
 
         # Insert test data
         with connection.cursor() as cursor:
-            cursor.execute("BEGIN")
             cursor.execute(
                 "INSERT INTO test_remove_field (name, code) VALUES (%s, %s)",
                 ["to_remove", "keep_this"],
             )
-            cursor.execute("COMMIT")
 
         field_to_remove = models.CharField(max_length=100, null=True)
         field_to_remove.set_attributes_from_name("name")
@@ -259,9 +246,11 @@ class TestRemakeTableAddField(unittest.TestCase):
     """Test add_field via table recreation on a real DSQL cluster."""
 
     def setUp(self):
+        connection.close()
         _drop_table_if_exists("test_add_field")
 
     def tearDown(self):
+        connection.close()
         _drop_table_if_exists("test_add_field")
 
     def _create_test_table(self, fields):
@@ -305,7 +294,7 @@ class TestRemakeTableAddField(unittest.TestCase):
     def test_add_not_null_field_with_default(self):
         """Test adding a NOT NULL field with a default to an existing table.
 
-        DSQL's ADD COLUMN only supports 'column_name data_type' — no DEFAULT
+        DSQL's ADD COLUMN only supports 'column_name data_type' -- no DEFAULT
         or NOT NULL inline. This must go through table recreation.
         """
         Model = self._create_test_table(
@@ -316,12 +305,10 @@ class TestRemakeTableAddField(unittest.TestCase):
 
         # Insert a row before adding the field
         with connection.cursor() as cursor:
-            cursor.execute("BEGIN")
             cursor.execute(
                 "INSERT INTO test_add_field (name) VALUES (%s)",
                 ["existing_row"],
             )
-            cursor.execute("COMMIT")
 
         new_field = models.CharField(max_length=50, default="pending")
         new_field.set_attributes_from_name("status")
@@ -342,7 +329,7 @@ class TestRemakeTableAddField(unittest.TestCase):
             self.assertEqual(rows[0][1], "pending")
 
     def test_add_nullable_field(self):
-        """Test adding a nullable field — should use simple ADD COLUMN."""
+        """Test adding a nullable field -- should use simple ADD COLUMN."""
         Model = self._create_test_table(
             {
                 "name": models.CharField(max_length=100),

--- a/python/django/aurora_dsql_django/tests/integration/test_schema_remake.py
+++ b/python/django/aurora_dsql_django/tests/integration/test_schema_remake.py
@@ -23,13 +23,17 @@ def _drop_table_if_exists(table_name):
 class TestRemakeTableAlterField(unittest.TestCase):
     """Test _alter_field via table recreation on a real DSQL cluster."""
 
+    TABLE = "test_alter_field"
+
     def setUp(self):
         connection.close()
-        _drop_table_if_exists("test_alter_field")
+        for t in [self.TABLE, f"old__{self.TABLE}", f"new__{self.TABLE}"]:
+            _drop_table_if_exists(t)
 
     def tearDown(self):
         connection.close()
-        _drop_table_if_exists("test_alter_field")
+        for t in [self.TABLE, f"old__{self.TABLE}", f"new__{self.TABLE}"]:
+            _drop_table_if_exists(t)
 
     def _create_test_table(self, fields):
         """Create a test table using the schema editor."""
@@ -155,13 +159,17 @@ class TestRemakeTableAlterField(unittest.TestCase):
 class TestRemakeTableRemoveField(unittest.TestCase):
     """Test remove_field via table recreation on a real DSQL cluster."""
 
+    TABLE = "test_remove_field"
+
     def setUp(self):
         connection.close()
-        _drop_table_if_exists("test_remove_field")
+        for t in [self.TABLE, f"old__{self.TABLE}", f"new__{self.TABLE}"]:
+            _drop_table_if_exists(t)
 
     def tearDown(self):
         connection.close()
-        _drop_table_if_exists("test_remove_field")
+        for t in [self.TABLE, f"old__{self.TABLE}", f"new__{self.TABLE}"]:
+            _drop_table_if_exists(t)
 
     def _create_test_table(self, fields):
         meta = type(
@@ -245,13 +253,17 @@ class TestRemakeTableRemoveField(unittest.TestCase):
 class TestRemakeTableAddField(unittest.TestCase):
     """Test add_field via table recreation on a real DSQL cluster."""
 
+    TABLE = "test_add_field"
+
     def setUp(self):
         connection.close()
-        _drop_table_if_exists("test_add_field")
+        for t in [self.TABLE, f"old__{self.TABLE}", f"new__{self.TABLE}"]:
+            _drop_table_if_exists(t)
 
     def tearDown(self):
         connection.close()
-        _drop_table_if_exists("test_add_field")
+        for t in [self.TABLE, f"old__{self.TABLE}", f"new__{self.TABLE}"]:
+            _drop_table_if_exists(t)
 
     def _create_test_table(self, fields):
         meta = type(

--- a/python/django/aurora_dsql_django/tests/test_settings.py
+++ b/python/django/aurora_dsql_django/tests/test_settings.py
@@ -27,9 +27,10 @@ USE_TZ = True
 
 # Add other necessary Django settings
 INSTALLED_APPS = [
+    "django.contrib.admin",
     "django.contrib.auth",
     "django.contrib.contenttypes",
-    # Add other apps as needed
+    "django.contrib.sessions",
 ]
 
 # Disable Django's transaction management

--- a/python/django/aurora_dsql_django/tests/unit/test_schema_remake.py
+++ b/python/django/aurora_dsql_django/tests/unit/test_schema_remake.py
@@ -9,6 +9,7 @@ verification paths in _remake_table behave correctly without requiring
 a real DSQL cluster.
 """
 
+import itertools
 import unittest
 from unittest.mock import MagicMock, patch
 
@@ -25,9 +26,13 @@ if not settings.configured:
 
 from aurora_dsql_django.schema import DatabaseSchemaEditor
 
+# Counter for unique model names to avoid Django re-registration warnings.
+_model_counter = itertools.count()
+
 
 def _make_model(table_name="test_table"):
     """Create a minimal dynamic model for _remake_table tests."""
+    n = next(_model_counter)
     meta = type(
         "Meta",
         (),
@@ -37,7 +42,7 @@ def _make_model(table_name="test_table"):
         },
     )
     return type(
-        "TestModel",
+        f"RemakeTestModel{n}",
         (models.Model,),
         {
             "__module__": "django.contrib.contenttypes.models",
@@ -69,6 +74,11 @@ def _setup_editor():
     return editor
 
 
+def _get_sql_strings(mock_execute):
+    """Extract SQL strings from mock execute call_args_list."""
+    return [str(c) for c in mock_execute.call_args_list]
+
+
 class TestRemakeTableRecovery(unittest.TestCase):
     """Test _remake_table step 0: recovery from prior failed attempts."""
 
@@ -90,12 +100,14 @@ class TestRemakeTableRecovery(unittest.TestCase):
         new_field = Model._meta.get_field("name")
         self.editor._remake_table(Model, alter_fields=[(old_field, new_field)])
 
-        execute_calls = [str(c) for c in mock_execute.call_args_list]
-        # Should DROP new__ (if exists) then RENAME old__ → original.
-        drop_new = any("DROP" in c and "new__" in c for c in execute_calls)
-        rename_old = any("RENAME" in c and "old__" in c for c in execute_calls)
-        self.assertTrue(drop_new, f"Expected DROP new__ in recovery, got: {execute_calls}")
-        self.assertTrue(rename_old, f"Expected RENAME old__ back in recovery, got: {execute_calls}")
+        calls = _get_sql_strings(mock_execute)
+        # First two calls should be the recovery: DROP new__ (cleanup) then RENAME old__ → original.
+        self.assertGreaterEqual(len(calls), 2, f"Expected at least 2 execute calls, got: {calls}")
+        self.assertIn("DROP", calls[0])
+        self.assertIn("new__", calls[0])
+        self.assertIn("RENAME", calls[1])
+        self.assertIn("old__", calls[1])
+        self.assertIn("test_table", calls[1])
 
     @patch.object(DatabaseSchemaEditor, "alter_db_table")
     @patch.object(DatabaseSchemaEditor, "create_model")
@@ -112,9 +124,12 @@ class TestRemakeTableRecovery(unittest.TestCase):
         new_field = Model._meta.get_field("name")
         self.editor._remake_table(Model, alter_fields=[(old_field, new_field)])
 
-        execute_calls = [str(c) for c in mock_execute.call_args_list]
-        rename_new = any("RENAME" in c and "new__" in c for c in execute_calls)
-        self.assertTrue(rename_new, f"Expected RENAME new__ back in recovery, got: {execute_calls}")
+        calls = _get_sql_strings(mock_execute)
+        # First call should be recovery: RENAME new__ → original.
+        self.assertGreaterEqual(len(calls), 1, f"Expected at least 1 execute call, got: {calls}")
+        self.assertIn("RENAME", calls[0])
+        self.assertIn("new__", calls[0])
+        self.assertIn("test_table", calls[0])
 
     @patch.object(DatabaseSchemaEditor, "execute")
     @patch.object(DatabaseSchemaEditor, "_table_exists")
@@ -129,6 +144,7 @@ class TestRemakeTableRecovery(unittest.TestCase):
             self.editor._remake_table(Model, alter_fields=[(old_field, new_field)])
 
         self.assertIn("Manual intervention required", str(ctx.exception))
+        self.assertIn("test_table", str(ctx.exception))
 
     @patch.object(DatabaseSchemaEditor, "alter_db_table")
     @patch.object(DatabaseSchemaEditor, "create_model")
@@ -136,7 +152,7 @@ class TestRemakeTableRecovery(unittest.TestCase):
     @patch.object(DatabaseSchemaEditor, "_query_with_retry")
     @patch.object(DatabaseSchemaEditor, "_table_exists")
     def test_cleanup_leftover_temp_tables(self, mock_exists, mock_query, mock_execute, mock_create, mock_alter):
-        """When original exists with leftover old__/new__, clean them up."""
+        """When original exists with leftover old__/new__, clean them up before proceeding."""
         mock_exists.side_effect = _table_exists_factory(original=True, old=True, new=True)
         mock_query.return_value = [(0,)]
 
@@ -145,11 +161,13 @@ class TestRemakeTableRecovery(unittest.TestCase):
         new_field = Model._meta.get_field("name")
         self.editor._remake_table(Model, alter_fields=[(old_field, new_field)])
 
-        execute_calls = [str(c) for c in mock_execute.call_args_list]
-        drop_old = any("DROP" in c and "old__" in c for c in execute_calls)
-        drop_new = any("DROP" in c and "new__" in c for c in execute_calls)
-        self.assertTrue(drop_old, f"Expected DROP old__ cleanup, got: {execute_calls}")
-        self.assertTrue(drop_new, f"Expected DROP new__ cleanup, got: {execute_calls}")
+        calls = _get_sql_strings(mock_execute)
+        # First two calls should be cleanup: DROP old__ then DROP new__.
+        self.assertGreaterEqual(len(calls), 2, f"Expected at least 2 execute calls, got: {calls}")
+        self.assertIn("DROP", calls[0])
+        self.assertIn("old__", calls[0])
+        self.assertIn("DROP", calls[1])
+        self.assertIn("new__", calls[1])
 
 
 class TestRemakeTableVerification(unittest.TestCase):
@@ -191,12 +209,14 @@ class TestRemakeTableVerification(unittest.TestCase):
         self.assertIn("got 3", error_msg)
         self.assertIn("Original table has been restored", error_msg)
 
-        # Verify it tried to restore: DROP new__ + RENAME old__ → original.
-        execute_calls = [str(c) for c in mock_execute.call_args_list]
-        drop_new = any("DROP" in c and "new__" in c for c in execute_calls)
-        rename_back = any("RENAME" in c and "old__" in c for c in execute_calls)
-        self.assertTrue(drop_new, f"Expected DROP new__ on verification failure, got: {execute_calls}")
-        self.assertTrue(rename_back, f"Expected RENAME old__ back on verification failure, got: {execute_calls}")
+        # Last two execute calls before the exception should be the restore:
+        # DROP new__ then RENAME old__ → original.
+        calls = _get_sql_strings(mock_execute)
+        self.assertIn("DROP", calls[-2])
+        self.assertIn("new__", calls[-2])
+        self.assertIn("RENAME", calls[-1])
+        self.assertIn("old__", calls[-1])
+        self.assertIn("test_table", calls[-1])
 
     @patch.object(DatabaseSchemaEditor, "alter_db_table")
     @patch.object(DatabaseSchemaEditor, "create_model")
@@ -213,10 +233,9 @@ class TestRemakeTableVerification(unittest.TestCase):
         new_field = Model._meta.get_field("name")
         self.editor._remake_table(Model, alter_fields=[(old_field, new_field)])
 
-        # Should not have any INSERT calls.
-        execute_calls = [str(c) for c in mock_execute.call_args_list]
-        inserts = [c for c in execute_calls if "INSERT" in c]
-        self.assertEqual(len(inserts), 0, f"Expected no INSERT for empty table, got: {execute_calls}")
+        calls = _get_sql_strings(mock_execute)
+        inserts = [c for c in calls if "INSERT" in c]
+        self.assertEqual(len(inserts), 0, f"Expected no INSERT for empty table, got: {calls}")
 
 
 if __name__ == "__main__":

--- a/python/django/aurora_dsql_django/tests/unit/test_schema_remake.py
+++ b/python/django/aurora_dsql_django/tests/unit/test_schema_remake.py
@@ -15,7 +15,7 @@ from unittest.mock import MagicMock, patch
 
 import django
 from django.conf import settings
-from django.db import models
+from django.db import OperationalError, models
 
 if not settings.configured:
     settings.configure(
@@ -236,6 +236,82 @@ class TestRemakeTableVerification(unittest.TestCase):
         calls = _get_sql_strings(mock_execute)
         inserts = [c for c in calls if "INSERT" in c]
         self.assertEqual(len(inserts), 0, f"Expected no INSERT for empty table, got: {calls}")
+
+    @patch.object(DatabaseSchemaEditor, "alter_db_table")
+    @patch.object(DatabaseSchemaEditor, "create_model")
+    @patch.object(DatabaseSchemaEditor, "execute")
+    @patch.object(DatabaseSchemaEditor, "_query_with_retry")
+    @patch.object(DatabaseSchemaEditor, "_table_exists")
+    def test_multi_batch_copy(self, mock_exists, mock_query, mock_execute, mock_create, mock_alter):
+        """A table with 2500 rows requires 3 batches of 1000."""
+        mock_exists.return_value = True
+
+        # _query_with_retry calls in order:
+        # 1. COUNT(*) FROM old__ → 2500
+        # 2. SELECT pk ... LIMIT 1 → seed pk
+        # 3. SELECT pk ... OFFSET → pk 1001 (next batch start)
+        # 4. SELECT pk ... OFFSET → pk 2001 (next batch start)
+        # 5. SELECT pk ... OFFSET → [] (no more rows)
+        # 6. COUNT(*) FROM new__ → 2500 (verification passes)
+        mock_query.side_effect = [
+            [(2500,)],  # total_rows
+            [(1,)],  # seed pk
+            [(1001,)],  # next batch start
+            [(2001,)],  # next batch start
+            [],  # no more rows
+            [(2500,)],  # copied_rows (matches)
+        ]
+
+        Model = _make_model()
+        old_field = Model._meta.get_field("name")
+        new_field = Model._meta.get_field("name")
+        self.editor._remake_table(Model, alter_fields=[(old_field, new_field)])
+
+        calls = _get_sql_strings(mock_execute)
+        inserts = [c for c in calls if "INSERT" in c]
+        self.assertEqual(len(inserts), 3, f"Expected 3 INSERT calls for 2500 rows, got: {inserts}")
+
+
+def _make_occ_error(sqlstate="OC001"):
+    """Create a mock OperationalError with a DSQL OCC sqlstate on __cause__."""
+    cause = Exception()
+    cause.sqlstate = sqlstate
+    exc = OperationalError()
+    exc.__cause__ = cause
+    return exc
+
+
+class TestOccRetry(unittest.TestCase):
+    """Test _occ_retry behavior for OCC error handling."""
+
+    def setUp(self):
+        self.editor = _setup_editor()
+
+    def test_occ_retry_succeeds_on_first_attempt(self):
+        """fn() succeeds immediately, verify called once."""
+        fn = MagicMock(return_value="ok")
+        result = self.editor._occ_retry(fn)
+        self.assertEqual(result, "ok")
+        fn.assert_called_once()
+
+    @patch("aurora_dsql_django.schema.time.sleep")
+    def test_occ_retry_succeeds_after_retry(self, mock_sleep):
+        """fn() raises OCC error on first call, succeeds on second."""
+        fn = MagicMock(side_effect=[_make_occ_error("OC001"), "ok"])
+        result = self.editor._occ_retry(fn)
+        self.assertEqual(result, "ok")
+        self.assertEqual(fn.call_count, 2)
+
+    def test_occ_retry_raises_non_occ_error(self):
+        """fn() raises a non-OCC OperationalError, verify it's raised immediately."""
+        cause = Exception()
+        cause.sqlstate = "42P01"  # Not an OCC error
+        exc = OperationalError()
+        exc.__cause__ = cause
+        fn = MagicMock(side_effect=exc)
+        with self.assertRaises(OperationalError):
+            self.editor._occ_retry(fn)
+        fn.assert_called_once()
 
 
 if __name__ == "__main__":

--- a/python/django/aurora_dsql_django/tests/unit/test_schema_remake.py
+++ b/python/django/aurora_dsql_django/tests/unit/test_schema_remake.py
@@ -1,0 +1,223 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Unit tests for _remake_table recovery logic and row count verification.
+
+These tests mock the database layer to verify that the recovery and
+verification paths in _remake_table behave correctly without requiring
+a real DSQL cluster.
+"""
+
+import unittest
+from unittest.mock import MagicMock, patch
+
+import django
+from django.conf import settings
+from django.db import models
+
+if not settings.configured:
+    settings.configure(
+        DATABASES={"default": {"ENGINE": "aurora_dsql_django"}},
+        INSTALLED_APPS=["django.contrib.contenttypes"],
+    )
+    django.setup()
+
+from aurora_dsql_django.schema import DatabaseSchemaEditor
+
+
+def _make_model(table_name="test_table"):
+    """Create a minimal dynamic model for _remake_table tests."""
+    meta = type(
+        "Meta",
+        (),
+        {
+            "app_label": "contenttypes",
+            "db_table": table_name,
+        },
+    )
+    return type(
+        "TestModel",
+        (models.Model,),
+        {
+            "__module__": "django.contrib.contenttypes.models",
+            "Meta": meta,
+            "name": models.CharField(max_length=100),
+        },
+    )
+
+
+def _table_exists_factory(original=True, old=False, new=False):
+    """Return a side_effect function for _table_exists based on table states."""
+
+    def _side_effect(table_name):
+        if "old__" in table_name:
+            return old
+        elif "new__" in table_name:
+            return new
+        return original
+
+    return _side_effect
+
+
+def _setup_editor():
+    """Create a DatabaseSchemaEditor with a properly configured mock connection."""
+    connection = MagicMock()
+    connection.ops.quote_name.side_effect = lambda name: f'"{name}"'
+    editor = DatabaseSchemaEditor(connection)
+    editor.deferred_sql = []
+    return editor
+
+
+class TestRemakeTableRecovery(unittest.TestCase):
+    """Test _remake_table step 0: recovery from prior failed attempts."""
+
+    def setUp(self):
+        self.editor = _setup_editor()
+
+    @patch.object(DatabaseSchemaEditor, "alter_db_table")
+    @patch.object(DatabaseSchemaEditor, "create_model")
+    @patch.object(DatabaseSchemaEditor, "execute")
+    @patch.object(DatabaseSchemaEditor, "_query_with_retry")
+    @patch.object(DatabaseSchemaEditor, "_table_exists")
+    def test_recovery_from_old_table(self, mock_exists, mock_query, mock_execute, mock_create, mock_alter):
+        """When only old__ exists (failed after rename), recover by renaming old__ back."""
+        mock_exists.side_effect = _table_exists_factory(original=False, old=True, new=False)
+        mock_query.return_value = [(0,)]
+
+        Model = _make_model()
+        old_field = Model._meta.get_field("name")
+        new_field = Model._meta.get_field("name")
+        self.editor._remake_table(Model, alter_fields=[(old_field, new_field)])
+
+        execute_calls = [str(c) for c in mock_execute.call_args_list]
+        # Should DROP new__ (if exists) then RENAME old__ → original.
+        drop_new = any("DROP" in c and "new__" in c for c in execute_calls)
+        rename_old = any("RENAME" in c and "old__" in c for c in execute_calls)
+        self.assertTrue(drop_new, f"Expected DROP new__ in recovery, got: {execute_calls}")
+        self.assertTrue(rename_old, f"Expected RENAME old__ back in recovery, got: {execute_calls}")
+
+    @patch.object(DatabaseSchemaEditor, "alter_db_table")
+    @patch.object(DatabaseSchemaEditor, "create_model")
+    @patch.object(DatabaseSchemaEditor, "execute")
+    @patch.object(DatabaseSchemaEditor, "_query_with_retry")
+    @patch.object(DatabaseSchemaEditor, "_table_exists")
+    def test_recovery_from_new_table(self, mock_exists, mock_query, mock_execute, mock_create, mock_alter):
+        """When only new__ exists (failed after DROP old__), recover by renaming new__ back."""
+        mock_exists.side_effect = _table_exists_factory(original=False, old=False, new=True)
+        mock_query.return_value = [(0,)]
+
+        Model = _make_model()
+        old_field = Model._meta.get_field("name")
+        new_field = Model._meta.get_field("name")
+        self.editor._remake_table(Model, alter_fields=[(old_field, new_field)])
+
+        execute_calls = [str(c) for c in mock_execute.call_args_list]
+        rename_new = any("RENAME" in c and "new__" in c for c in execute_calls)
+        self.assertTrue(rename_new, f"Expected RENAME new__ back in recovery, got: {execute_calls}")
+
+    @patch.object(DatabaseSchemaEditor, "execute")
+    @patch.object(DatabaseSchemaEditor, "_table_exists")
+    def test_recovery_no_tables_raises(self, mock_exists, mock_execute):
+        """When none of the three tables exist, raise RuntimeError."""
+        mock_exists.side_effect = _table_exists_factory(original=False, old=False, new=False)
+
+        Model = _make_model()
+        old_field = Model._meta.get_field("name")
+        new_field = Model._meta.get_field("name")
+        with self.assertRaises(RuntimeError) as ctx:
+            self.editor._remake_table(Model, alter_fields=[(old_field, new_field)])
+
+        self.assertIn("Manual intervention required", str(ctx.exception))
+
+    @patch.object(DatabaseSchemaEditor, "alter_db_table")
+    @patch.object(DatabaseSchemaEditor, "create_model")
+    @patch.object(DatabaseSchemaEditor, "execute")
+    @patch.object(DatabaseSchemaEditor, "_query_with_retry")
+    @patch.object(DatabaseSchemaEditor, "_table_exists")
+    def test_cleanup_leftover_temp_tables(self, mock_exists, mock_query, mock_execute, mock_create, mock_alter):
+        """When original exists with leftover old__/new__, clean them up."""
+        mock_exists.side_effect = _table_exists_factory(original=True, old=True, new=True)
+        mock_query.return_value = [(0,)]
+
+        Model = _make_model()
+        old_field = Model._meta.get_field("name")
+        new_field = Model._meta.get_field("name")
+        self.editor._remake_table(Model, alter_fields=[(old_field, new_field)])
+
+        execute_calls = [str(c) for c in mock_execute.call_args_list]
+        drop_old = any("DROP" in c and "old__" in c for c in execute_calls)
+        drop_new = any("DROP" in c and "new__" in c for c in execute_calls)
+        self.assertTrue(drop_old, f"Expected DROP old__ cleanup, got: {execute_calls}")
+        self.assertTrue(drop_new, f"Expected DROP new__ cleanup, got: {execute_calls}")
+
+
+class TestRemakeTableVerification(unittest.TestCase):
+    """Test _remake_table row count verification after copy."""
+
+    def setUp(self):
+        self.editor = _setup_editor()
+
+    @patch.object(DatabaseSchemaEditor, "alter_db_table")
+    @patch.object(DatabaseSchemaEditor, "create_model")
+    @patch.object(DatabaseSchemaEditor, "execute")
+    @patch.object(DatabaseSchemaEditor, "_query_with_retry")
+    @patch.object(DatabaseSchemaEditor, "_table_exists")
+    def test_row_count_mismatch_raises_and_restores(self, mock_exists, mock_query, mock_execute, mock_create, mock_alter):
+        """When copied row count doesn't match source, abort and restore original table."""
+        mock_exists.return_value = True
+
+        # _query_with_retry calls in order:
+        # 1. COUNT(*) FROM old__ → 5 rows
+        # 2. SELECT pk ... LIMIT 1 → seed pk
+        # 3. SELECT pk ... OFFSET → no more rows (single batch)
+        # 4. COUNT(*) FROM new__ → 3 rows (mismatch!)
+        mock_query.side_effect = [
+            [(5,)],  # total_rows
+            [(1,)],  # seed pk
+            [],  # no more batches
+            [(3,)],  # copied_rows (mismatch)
+        ]
+
+        Model = _make_model()
+        old_field = Model._meta.get_field("name")
+        new_field = Model._meta.get_field("name")
+        with self.assertRaises(RuntimeError) as ctx:
+            self.editor._remake_table(Model, alter_fields=[(old_field, new_field)])
+
+        error_msg = str(ctx.exception)
+        self.assertIn("copy verification failed", error_msg)
+        self.assertIn("expected 5", error_msg)
+        self.assertIn("got 3", error_msg)
+        self.assertIn("Original table has been restored", error_msg)
+
+        # Verify it tried to restore: DROP new__ + RENAME old__ → original.
+        execute_calls = [str(c) for c in mock_execute.call_args_list]
+        drop_new = any("DROP" in c and "new__" in c for c in execute_calls)
+        rename_back = any("RENAME" in c and "old__" in c for c in execute_calls)
+        self.assertTrue(drop_new, f"Expected DROP new__ on verification failure, got: {execute_calls}")
+        self.assertTrue(rename_back, f"Expected RENAME old__ back on verification failure, got: {execute_calls}")
+
+    @patch.object(DatabaseSchemaEditor, "alter_db_table")
+    @patch.object(DatabaseSchemaEditor, "create_model")
+    @patch.object(DatabaseSchemaEditor, "execute")
+    @patch.object(DatabaseSchemaEditor, "_query_with_retry")
+    @patch.object(DatabaseSchemaEditor, "_table_exists")
+    def test_empty_table_skips_copy(self, mock_exists, mock_query, mock_execute, mock_create, mock_alter):
+        """When source table has 0 rows, skip copy entirely."""
+        mock_exists.return_value = True
+        mock_query.return_value = [(0,)]
+
+        Model = _make_model()
+        old_field = Model._meta.get_field("name")
+        new_field = Model._meta.get_field("name")
+        self.editor._remake_table(Model, alter_fields=[(old_field, new_field)])
+
+        # Should not have any INSERT calls.
+        execute_calls = [str(c) for c in mock_execute.call_args_list]
+        inserts = [c for c in execute_calls if "INSERT" in c]
+        self.assertEqual(len(inserts), 0, f"Expected no INSERT for empty table, got: {execute_calls}")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Aurora DSQL does not support `ALTER COLUMN` (TYPE, SET/DROP NOT NULL, SET/DROP DEFAULT) or `DROP COLUMN`. Django's default contrib app migrations (`auth`, `contenttypes`) use these operations, causing `FeatureNotSupported` errors on fresh deployments with standard `INSTALLED_APPS`.

This implements a **rename-first table recreation pattern** in the DSQL schema editor to handle these operations transparently. The pattern is adapted from Django's SQLite backend but simplified for DSQL (no FK handling, no check constraints).

### How it works

To prevent silent data loss from concurrent writes, the original table is renamed first to freeze it before copying data:

0. **Recover** from any previous failed `_remake_table` attempt (detect leftover `old__`/`new__` tables and restore)
1. **Rename** original → `old__<table>` (freezes writes — any writes to the original name fail loudly)
2. **Create** `new__<table>` with the updated schema
3. **Copy** data from `old__<table>` into `new__<table>` (batched with cursor-based pagination to stay within DSQL's 3000 row limit)
4. **Verify** row count matches before proceeding (aborts and restores if mismatch)
5. **Drop** `old__<table>`
6. **Rename** `new__<table>` → original
7. **Recreate** indexes via deferred SQL

> **Warning:** This is designed for **development iteration**, not production use on tables with significant data. The table is unavailable under its original name during the recreation window (between steps 1 and 6). For production schema changes, consider blue/green deployments or manual migration strategies.

### Previously failing migrations now handled automatically

| Migration | Operation |
|-----------|-----------|
| `contenttypes.0002` | `ALTER COLUMN name DROP NOT NULL` + `DROP COLUMN name` |
| `auth.0002` | `ALTER COLUMN name TYPE varchar(255)` |
| `auth.0003` | `ALTER COLUMN email TYPE varchar(254)` |
| `auth.0005` | `ALTER COLUMN last_login DROP NOT NULL` |
| `auth.0008` | `ALTER COLUMN username TYPE varchar(150)` |
| `auth.0009` | `ALTER COLUMN last_name TYPE varchar(150)` |
| `auth.0010` | `ALTER COLUMN name TYPE varchar(150)` |
| `auth.0012` | `ALTER COLUMN first_name TYPE varchar(150)` |

### Override surface

- **`_remake_table()`** — rename-first table recreation with failure recovery, batched copy, and row count verification
- **`_alter_field()`** — routes to `_remake_table`; preserves fast path for `RENAME COLUMN`
- **`add_field()`** — routes to `_remake_table` when field needs constraints/defaults (DSQL's `ADD COLUMN` only supports bare `name type`)
- **`remove_field()`** — routes to `_remake_table` since `DROP COLUMN` is unsupported
- **`execute()`** — automatic OCC retry (only for OC000/OC001 sqlstates, not all OperationalErrors)
- **`_is_occ_error()`** — static method to identify DSQL OCC conflicts by sqlstate
- **`_table_exists()`** — helper to check table existence in the current schema

### Data safety

- The source table (`old__`) is kept until the copy is verified by row count
- Any failure before verification recovers from `old__`
- After verification, `old__` is dropped and any subsequent failure recovers from `new__`
- No code path loses data silently

### Transaction safety

Since `can_rollback_ddl = False`, each `self.execute()` call auto-commits independently. This naturally satisfies DSQL's one-DDL-per-transaction rule without special transaction handling. OCC errors (OC000/OC001) are retried automatically via `execute()`.

## Test plan

- [x] 101 existing unit tests pass (no regressions)
- [ ] Integration tests: `test_schema_remake.py` — ALTER field (varchar length, nullability), data preservation, remove field, add NOT NULL field with default, add nullable field
- [ ] Integration tests: `test_contrib_migrations.py` — full `migrate` with `django.contrib.auth`, `contenttypes`, `admin`, `sessions` against a real DSQL cluster