### PR TITLE
fix(prisma): reject unknown CLI flags instead of silently ignoring them

### DIFF
--- a/node/prisma/src/cli/index.ts
+++ b/node/prisma/src/cli/index.ts
@@ -44,6 +44,15 @@ Examples:
   npm run dsql-transform raw.sql -o migration.sql
 `;
 
+function rejectUnknownFlags(args: string[], knownFlags: Set<string>): void {
+  for (const arg of args) {
+    if (arg.startsWith("-") && !knownFlags.has(arg)) {
+      console.error(`Error: Unknown flag: ${arg}`);
+      process.exit(1);
+    }
+  }
+}
+
 async function main(): Promise<void> {
   const args = process.argv.slice(2);
 
@@ -61,7 +70,10 @@ async function main(): Promise<void> {
     }
 
     case "validate": {
-      const schemaPath = args[1];
+      const subArgs = args.slice(1);
+      rejectUnknownFlags(subArgs, new Set(["-h", "--help"]));
+
+      const schemaPath = subArgs.find((a) => !a.startsWith("-"));
       if (!schemaPath) {
         console.error("Error: Schema path required");
         console.error("Usage: npm run validate <schema>");
@@ -120,6 +132,17 @@ Examples:
 `);
     process.exit(0);
   }
+
+  const knownFlags = new Set([
+    "-o",
+    "--output",
+    "--from-url",
+    "--from-config-datasource",
+    "--from-empty",
+    "-h",
+    "--help",
+  ]);
+  rejectUnknownFlags(args, knownFlags);
 
   let schemaPath: string | undefined;
   let outputFile: string | undefined;
@@ -252,6 +275,8 @@ Options:
     process.exit(0);
   }
 
+  rejectUnknownFlags(args, new Set(["-o", "--output", "-h", "--help"]));
+
   let inputFile: string | undefined;
   let outputFile: string | undefined;
 
@@ -314,6 +339,8 @@ Options:
 `);
     process.exit(0);
   }
+
+  rejectUnknownFlags(args, new Set(["-h", "--help"]));
 
   const inputFile = args.find((a) => !a.startsWith("-"));
   if (!inputFile) {

--- a/node/prisma/test/cli-integration.test.ts
+++ b/node/prisma/test/cli-integration.test.ts
@@ -238,6 +238,66 @@ CREATE INDEX "post_authorId_idx" ON "post"("authorId");`;
       expect(output).toContain('CREATE TABLE "post"');
     });
 
+    test("validate rejects unknown flags", () => {
+      try {
+        execSync(`npm run validate -- --unknown-flag`, {
+          cwd: path.join(__dirname, ".."),
+          encoding: "utf-8",
+          stdio: "pipe",
+        });
+        fail("Expected CLI to fail on unknown flag");
+      } catch (error: unknown) {
+        const execError = error as { stderr?: string; status?: number };
+        expect(execError.stderr).toContain("Unknown flag: --unknown-flag");
+        expect(execError.status).toBe(1);
+      }
+    });
+
+    test("migrate rejects unknown flags", () => {
+      try {
+        execSync(`npm run dsql-migrate -- schema.prisma -o out.sql --bogus`, {
+          cwd: path.join(__dirname, ".."),
+          encoding: "utf-8",
+          stdio: "pipe",
+        });
+        fail("Expected CLI to fail on unknown flag");
+      } catch (error: unknown) {
+        const execError = error as { stderr?: string; status?: number };
+        expect(execError.stderr).toContain("Unknown flag: --bogus");
+        expect(execError.status).toBe(1);
+      }
+    });
+
+    test("transform rejects unknown flags", () => {
+      try {
+        execSync(`npm run dsql-transform -- --verbose`, {
+          cwd: path.join(__dirname, ".."),
+          encoding: "utf-8",
+          stdio: "pipe",
+        });
+        fail("Expected CLI to fail on unknown flag");
+      } catch (error: unknown) {
+        const execError = error as { stderr?: string; status?: number };
+        expect(execError.stderr).toContain("Unknown flag: --verbose");
+        expect(execError.status).toBe(1);
+      }
+    });
+
+    test("lint rejects unknown flags", () => {
+      try {
+        execSync(`npm run dsql-lint -- --fix`, {
+          cwd: path.join(__dirname, ".."),
+          encoding: "utf-8",
+          stdio: "pipe",
+        });
+        fail("Expected CLI to fail on unknown flag");
+      } catch (error: unknown) {
+        const execError = error as { stderr?: string; status?: number };
+        expect(execError.stderr).toContain("Unknown flag: --fix");
+        expect(execError.status).toBe(1);
+      }
+    });
+
     test("prisma migrate diff piped to dsql-transform produces valid output", () => {
       const output = execSync(
         "npx prisma migrate diff --from-empty --to-schema prisma/veterinary-schema.prisma --script | npm run dsql-transform 2>/dev/null",


### PR DESCRIPTION
## Summary

- All four CLI commands (`migrate`, `validate`, `transform`, `lint`) now error on unknown flags instead of silently ignoring them.
- Each command defines its known flags and calls `rejectUnknownFlags()` before parsing arguments.
- Error message format: `Error: Unknown flag: --whatever`

## Test plan

- [x] `validate --unknown-flag` exits 1 with "Unknown flag" message
- [x] `migrate schema.prisma -o out.sql --bogus` exits 1 with "Unknown flag" message
- [x] `transform --verbose` exits 1 with "Unknown flag" message
- [x] `lint --fix` exits 1 with "Unknown flag" message
- [x] All existing tests still pass (60 tests)