### PR TITLE
fix(ci): grant update-changelog job write permissions in node-prisma release

### DIFF
--- a/.github/workflows/node-prisma-release.yml
+++ b/.github/workflows/node-prisma-release.yml
@@ -57,4 +57,7 @@ jobs:
     uses: ./.github/workflows/update-changelog.yml
     with:
       tag: ${{ github.ref_name }}
+    permissions:
+      contents: write
+      pull-requests: write
     secrets: inherit


### PR DESCRIPTION
## Summary

The node-prisma release workflow has been failing at startup since v0.1.0 — both v0.1.1 and v0.1.2 tag pushes produced `startup_failure` with zero jobs logged. Root cause is a permissions mismatch:

```
Error calling workflow '.../update-changelog.yml'. The nested job
'update-changelog' is requesting 'contents: write, pull-requests: write',
but is only allowed 'contents: none, pull-requests: none'.
```

The top-level `permissions: {}` in `node-prisma-release.yml` restricts every job to no permissions. When we then call `update-changelog.yml` — which requires `contents: write` + `pull-requests: write` to open its changelog PR — the call exceeds the cap and the whole workflow fails before any job starts.

Fix: grant the `update-changelog` job the exact permissions it needs. This is the standard pattern for reusable workflows with elevated permissions.

## Unblocking the stuck v0.1.2 release

Once this merges:
1. Delete the `node/prisma/v0.1.2` tag (it points at the right commit but the failed run can't be retried across the workflow-file change)
2. Re-tag and push — the publish should succeed

## Related

The same pattern exists in these release workflows, which also have `permissions: {}` at the top and call `update-changelog.yml` without per-job permissions:

- `.github/workflows/java-hibernate-release.yml`
- `.github/workflows/python-django-release.yml`
- `.github/workflows/python-sqlalchemy-release.yml`
- `.github/workflows/python-tortoise-release.yml`

I'd recommend a follow-up PR to fix them before their next releases are cut.

## Test plan

- [x] `actionlint` passes on the updated workflow
- [ ] After merge: retag `node/prisma/v0.1.2` and confirm the release workflow runs through `publish-to-npm` and `update-changelog`
- [ ] Confirm `npm view @aws/aurora-dsql-prisma-tools version` returns `0.1.2`