### PR TITLE
fix(ci): upgrade npm before publishing to enable Trusted Publishing

### DIFF
--- a/.github/workflows/node-prisma-release.yml
+++ b/.github/workflows/node-prisma-release.yml
@@ -43,6 +43,12 @@ jobs:
           node-version: "22.x"
           registry-url: "https://registry.npmjs.org"
 
+      # Node 22's bundled npm (10.x) does not perform the OIDC token
+      # exchange required for Trusted Publishing — only npm >= 11.5.1
+      # does. Upgrade before publishing.
+      - name: Upgrade npm to support Trusted Publishing
+        run: npm install -g npm@latest
+
       - name: Install dependencies
         run: npm ci
 


### PR DESCRIPTION
## Summary

- Node 22 ships npm 10.x, which does not perform the OIDC token exchange required for Trusted Publishing — only npm >= 11.5.1 does.
- Both v0.1.1 and v0.1.2 release attempts have failed at the publish step with `npm error 404 Not Found - PUT https://registry.npmjs.org/@aws%2faurora-dsql-prisma-tools` despite the Sigstore provenance statement being signed and accepted.
- This PR adds an `npm install -g npm@latest` step before publishing so trusted publishing works end-to-end.

Sigstore log entries showing successful OIDC issuance followed by a 404 PUT (the smoking gun — provenance signed, then unauthenticated publish):
- `logIndex=1438593379` (2026-05-04, v0.1.2 first attempt)
- `logIndex=1520709995` (2026-05-12 retry)
- `logIndex=1520732548` (2026-05-12 retry)

## Test plan

- [ ] Merge this PR
- [ ] Delete and re-push the `node/prisma/v0.1.2` tag (or cut `v0.1.3`)
- [ ] Confirm the release workflow publishes successfully and `@aws/aurora-dsql-prisma-tools@0.1.2` (or `0.1.3`) appears on npm