### PR TITLE
fix(ci): make npm self-upgrade reliable in release workflow

### DIFF
--- a/.github/workflows/node-prisma-release.yml
+++ b/.github/workflows/node-prisma-release.yml
@@ -45,9 +45,10 @@ jobs:
 
       # Node 22's bundled npm (10.x) does not perform the OIDC token
       # exchange required for Trusted Publishing — only npm >= 11.5.1
-      # does. Upgrade before publishing.
+      # does. Upgrade before publishing. The pinned version + --force
+      # avoids npm 10's MODULE_NOT_FOUND while replacing itself.
       - name: Upgrade npm to support Trusted Publishing
-        run: npm install -g npm@latest
+        run: sudo npm install -g npm@11.5.1 --force
 
       - name: Install dependencies
         run: npm ci


### PR DESCRIPTION
## Summary

Follow-up to #440. The naive `npm install -g npm@latest` form fails with `MODULE_NOT_FOUND: promise-retry` while npm 10 replaces itself. Switch to `sudo npm install -g npm@11.5.1 --force`:

- `sudo`: clean writes to the global node_modules.
- `--force`: lets npm overwrite its own files without bailing on integrity checks.
- Pinned `11.5.1`: first npm release with Trusted Publishing support; avoids future churn from `latest`.

## Test plan

- [ ] Merge
- [ ] Re-tag node/prisma/v0.1.2 (or just re-run the release workflow on the existing tag)
- [ ] Confirm @aws/aurora-dsql-prisma-tools@0.1.2 lands on npm