### PR TITLE
fix(ci): clear NODE_AUTH_TOKEN to force OIDC trusted publishing

### DIFF
--- a/.github/workflows/node-prisma-release.yml
+++ b/.github/workflows/node-prisma-release.yml
@@ -56,6 +56,26 @@ jobs:
       - name: Build package
         run: npm run build
 
+      - name: Diagnose npm environment
+        # Temporary diagnostic to confirm trusted-publishing prerequisites
+        # (npm version, PATH, .npmrc, env). Remove once we have a green
+        # publish.
+        run: |
+          echo "which npm: $(which npm)"
+          echo "npm --version: $(npm --version)"
+          echo "node --version: $(node --version)"
+          echo
+          echo "PATH: $PATH"
+          echo
+          echo "~/.npmrc:"
+          cat ~/.npmrc 2>/dev/null || echo "(none)"
+          echo
+          echo ".npmrc (cwd):"
+          cat .npmrc 2>/dev/null || echo "(none)"
+          echo
+          echo "npm-related env vars (values redacted):"
+          env | grep -iE '^(npm|node_auth|registry)' | sed 's/=.*/=<redacted>/' || true
+
       - name: Publish to npm
         # Unset NODE_AUTH_TOKEN: actions/setup-node sets a placeholder token
         # whenever `registry-url` is configured, and npm prefers that token

--- a/.github/workflows/node-prisma-release.yml
+++ b/.github/workflows/node-prisma-release.yml
@@ -57,7 +57,12 @@ jobs:
         run: npm run build
 
       - name: Publish to npm
+        # Unset NODE_AUTH_TOKEN: actions/setup-node sets a placeholder token
+        # whenever `registry-url` is configured, and npm prefers that token
+        # over OIDC trusted publishing. Clearing it forces the OIDC path.
         run: npm publish
+        env:
+          NODE_AUTH_TOKEN: ""
 
   update-changelog:
     needs: publish-to-npm

--- a/.github/workflows/node-prisma-release.yml
+++ b/.github/workflows/node-prisma-release.yml
@@ -67,8 +67,8 @@ jobs:
           echo
           echo "PATH: $PATH"
           echo
-          echo "~/.npmrc:"
-          cat ~/.npmrc 2>/dev/null || echo "(none)"
+          echo "$HOME/.npmrc:"
+          cat "$HOME/.npmrc" 2>/dev/null || echo "(none)"
           echo
           echo ".npmrc (cwd):"
           cat .npmrc 2>/dev/null || echo "(none)"


### PR DESCRIPTION
## Summary

Third and (hopefully) final fix to get the npm release workflow working with trusted publishing.

\`actions/setup-node\` sets \`NODE_AUTH_TOKEN\` to a placeholder whenever \`registry-url\` is configured. With npm 11.5.1+ now installed (#441), npm checks for a token first and falls back to OIDC only when no token is set. The placeholder causes npm to try token auth, get rejected by the registry, and 404.

Clearing \`NODE_AUTH_TOKEN\` on the publish step forces the OIDC path.

## Test plan

- [ ] Merge
- [ ] Re-tag node/prisma/v0.1.2 against new main
- [ ] Confirm @aws/aurora-dsql-prisma-tools@0.1.2 lands on npm