### PR TITLE
fix(ci): drop sudo from npm self-upgrade so it actually replaces toolcache npm

### DIFF
--- a/.github/workflows/node-prisma-release.yml
+++ b/.github/workflows/node-prisma-release.yml
@@ -45,10 +45,12 @@ jobs:
 
       # Node 22's bundled npm (10.x) does not perform the OIDC token
       # exchange required for Trusted Publishing — only npm >= 11.5.1
-      # does. Upgrade before publishing. The pinned version + --force
-      # avoids npm 10's MODULE_NOT_FOUND while replacing itself.
+      # does. Install over the toolcache (no sudo) so the upgraded
+      # binary is what `which npm` resolves on PATH. With sudo, the
+      # install lands in /usr/local/bin which is shadowed by the
+      # toolcache directory earlier on PATH.
       - name: Upgrade npm to support Trusted Publishing
-        run: sudo npm install -g npm@11.5.1 --force
+        run: npm install -g npm@11.5.1
 
       - name: Install dependencies
         run: npm ci


### PR DESCRIPTION
## Summary

Diagnostic step from #442 (run 25816856737) showed that the publish step was *still* using npm 10.9.7 at `/opt/hostedtoolcache/node/22.22.2/x64/bin/npm`, even though our \"Upgrade npm\" step ran successfully and reported \"changed 108 packages\". \`sudo npm install -g\` writes to \`/usr/local/lib/node_modules\`, but \`/opt/hostedtoolcache/.../bin\` is earlier on PATH and shadows it.

This PR drops the \`sudo\` so npm overwrites itself in the toolcache directly. Hosted runners' toolcache is user-writable, so this is safe.

This also means PR #442's \`NODE_AUTH_TOKEN: \"\"\` workaround was solving a non-issue — the actual problem all along was that npm 10 doesn't support trusted publishing. We can revert that change in a followup once we verify this works.

## Test plan

- [ ] Merge
- [ ] Re-tag node/prisma/v0.1.2 against new main
- [ ] Confirm @aws/aurora-dsql-prisma-tools@0.1.2 lands on npm
- [ ] Followup PR removes the diagnostic step + the NODE_AUTH_TOKEN env override