### PR TITLE
Enable native JSONB support in adapters

### DIFF
--- a/python/django/aurora_dsql_django/features.py
+++ b/python/django/aurora_dsql_django/features.py
@@ -37,9 +37,6 @@ class DatabaseFeatures(features.DatabaseFeatures):
     # Does the database support deferrable unique constraints?
     supports_deferrable_unique_constraints = False
 
-    # Does the database have native JSON field support?
-    has_native_json_field = False
-
     # Can the database introspect materialized views?
     can_introspect_materialized_views = False
 

--- a/python/django/aurora_dsql_django/tests/unit/test_features.py
+++ b/python/django/aurora_dsql_django/tests/unit/test_features.py
@@ -36,9 +36,6 @@ class TestDatabaseFeatures(unittest.TestCase):
     def test_supports_deferrable_unique_constraints(self):
         self.assertFalse(self.features.supports_deferrable_unique_constraints)
 
-    def test_has_native_json_field(self):
-        self.assertFalse(self.features.has_native_json_field)
-
     def test_can_introspect_materialized_views(self):
         self.assertFalse(self.features.can_introspect_materialized_views)
 
@@ -68,7 +65,6 @@ class TestDatabaseFeatures(unittest.TestCase):
         self.assertNotEqual(self.features.can_rollback_ddl, postgresql_features.can_rollback_ddl)
         self.assertNotEqual(self.features.supports_foreign_keys, postgresql_features.supports_foreign_keys)
         self.assertNotEqual(self.features.can_clone_databases, postgresql_features.can_clone_databases)
-        self.assertNotEqual(self.features.has_native_json_field, postgresql_features.has_native_json_field)
 
 
 if __name__ == "__main__":

--- a/python/sqlalchemy/README.md
+++ b/python/sqlalchemy/README.md
@@ -145,7 +145,6 @@ See the [Working with sequences and identity columns](https://docs.aws.amazon.co
 
 ## Dialect Features
 
-- **Column Metadata**: The dialect fixes an issue related to `"datatype json not supported"` when calling SQLAlchemy's metadata() API.
 - **Foreign Keys**: The dialect disables foreign key constraint generation. Referential integrity should be maintained at the application level.
 - **Index Creation**: The dialect uses `CREATE INDEX ASYNC` and `CREATE UNIQUE INDEX ASYNC` commands. See the [Asynchronous indexes in Aurora DSQL](https://docs.aws.amazon.com/aurora-dsql/latest/userguide/working-with-create-index-async.html) page for more information.
 

--- a/python/sqlalchemy/aurora_dsql_sqlalchemy/base.py
+++ b/python/sqlalchemy/aurora_dsql_sqlalchemy/base.py
@@ -6,8 +6,10 @@ from functools import lru_cache
 from sqlalchemy import BIGINT, Integer, bindparam, select, sql
 from sqlalchemy.dialects.postgresql import pg_catalog
 from sqlalchemy.dialects.postgresql.base import PGDDLCompiler, PGDialect, PGTypeCompiler
+from sqlalchemy.dialects.postgresql.types import OID, REGCLASS
 from sqlalchemy.schema import ForeignKeyConstraint, PrimaryKeyConstraint
-from sqlalchemy.sql import expression
+from sqlalchemy.sql import expression, sqltypes
+from sqlalchemy.types import TEXT
 
 
 class AuroraDSQLDDLCompiler(PGDDLCompiler):
@@ -259,13 +261,54 @@ class AuroraDSQLDialect(PGDialect):
             else sql.null().label("generated")
         )
 
-        # the original code uses sql.func.json_build_object when server_version is
-        # greater than version 10
-        # json_build_object is not supported by Aurora DSQL
-        # TODO: if json_build_object is supported in the future,
-        # restore _columns_query function from original
-
-        identity = sql.null().label("identity_options")
+        # join lateral performs worse (~2x slower) than a scalar_subquery
+        identity = (
+            select(
+                sql.func.json_build_object(
+                    "always",
+                    pg_catalog.pg_attribute.c.attidentity == "a",
+                    "start",
+                    pg_catalog.pg_sequence.c.seqstart,
+                    "increment",
+                    pg_catalog.pg_sequence.c.seqincrement,
+                    "minvalue",
+                    pg_catalog.pg_sequence.c.seqmin,
+                    "maxvalue",
+                    pg_catalog.pg_sequence.c.seqmax,
+                    "cache",
+                    pg_catalog.pg_sequence.c.seqcache,
+                    "cycle",
+                    pg_catalog.pg_sequence.c.seqcycle,
+                    type_=sqltypes.JSON(),
+                )
+            )
+            .select_from(pg_catalog.pg_sequence)
+            .where(
+                # attidentity != '' is required or it will reflect also
+                # serial columns as identity.
+                pg_catalog.pg_attribute.c.attidentity != "",
+                pg_catalog.pg_sequence.c.seqrelid
+                == sql.cast(
+                    sql.cast(
+                        pg_catalog.pg_get_serial_sequence(
+                            sql.cast(
+                                sql.cast(
+                                    pg_catalog.pg_attribute.c.attrelid,
+                                    REGCLASS,
+                                ),
+                                TEXT,
+                            ),
+                            pg_catalog.pg_attribute.c.attname,
+                        ),
+                        REGCLASS,
+                    ),
+                    OID,
+                ),
+            )
+            .correlate(pg_catalog.pg_attribute)
+            .scalar_subquery()
+            .label("identity_options")
+        )
 
         # join lateral performs the same as scalar_subquery here
         default = (

--- a/python/tortoise-orm/README.md
+++ b/python/tortoise-orm/README.md
@@ -112,7 +112,6 @@ TORTOISE_ORM = {
 The compatibility module patches Aerich to:
 - Use UUID primary keys for migration tracking
 - Execute DDL statements individually (DSQL transactions support only one DDL statement)
-- Use TEXT instead of JSON column types
 
 ## Features and Limitations
 

--- a/python/tortoise-orm/aurora_dsql_tortoise/aerich/patch.py
+++ b/python/tortoise-orm/aurora_dsql_tortoise/aerich/patch.py
@@ -7,7 +7,6 @@ from pathlib import Path
 import aerich.migrate
 import aerich.models
 from aerich import Command
-from aerich.coder import decoder, encoder
 from aerich.ddl.postgres import PostgresDDL
 from aerich.exceptions import DowngradeError
 from aerich.migrate import Migrate
@@ -35,15 +34,6 @@ _uuid_field.model = aerich.models.Aerich
 _uuid_field.model_field_name = "id"
 aerich.models.Aerich._meta.fields_map["id"] = _uuid_field
 aerich.models.Aerich._meta.pk = _uuid_field
-
-
-# Patch Aerich internal model JSON field to use TEXT.
-_json_field = fields.JSONField(encoder=encoder, decoder=decoder)
-_json_field.model = aerich.models.Aerich
-_json_field.model_field_name = "content"
-_json_field.SQL_TYPE = "TEXT"
-_json_field._db_postgres = type("_", (), {"SQL_TYPE": "TEXT"})  # type: ignore[method-assign]
-aerich.models.Aerich._meta.fields_map["content"] = _json_field
 
 # Patch ordering to use version instead of id (UUIDs don't sort chronologically).
 aerich.models.Aerich._meta._default_ordering = (("version", Order.desc),)

--- a/python/tortoise-orm/docs/ADAPTER_BEHAVIOR.md
+++ b/python/tortoise-orm/docs/ADAPTER_BEHAVIOR.md
@@ -61,8 +61,6 @@ When `aurora_dsql_tortoise.aerich_compat` is included in your models, the follow
 
 **UUID primary keys for Aerich model:** The internal Aerich model uses `UUID` instead of auto-increment integer for its primary key.
 
-**TEXT instead of JSON:** The Aerich model's `content` field uses `TEXT` instead of `JSON`/`JSONB` column types.
-
 **Individual DDL execution:** Migration files may contain multiple DDL statements. The compatibility module splits these and executes each statement separately.
 
 **Disabled transaction wrapping:** Generated migration files set `RUN_IN_TRANSACTION = False` for DDL compatibility.

--- a/python/tortoise-orm/docs/KNOWN_ISSUES.md
+++ b/python/tortoise-orm/docs/KNOWN_ISSUES.md
@@ -2,12 +2,6 @@
 
 This document tracks known issues when using the Aurora DSQL adapter for Tortoise ORM. For Aurora DSQL SQL compatibility details, see the [Aurora DSQL documentation](https://docs.aws.amazon.com/aurora-dsql/latest/userguide/working-with-postgresql-compatibility.html).
 
-## JSONField
-
-**Issue:** Using `fields.JSONField` fails.
-
-**Workaround:** Use `fields.TextField` and handle JSON serialization in your application code.
-
 ## Nested transactions
 
 **Issue:** Nested `in_transaction()` or `atomic()` blocks fail.

--- a/python/tortoise-orm/tests/unit/test_aerich_compat.py
+++ b/python/tortoise-orm/tests/unit/test_aerich_compat.py
@@ -67,10 +67,8 @@ async def test():
     import aerich.migrate
 
     pk = aerich.models.Aerich._meta.pk
-    content = aerich.models.Aerich._meta.fields_map['content']
 
     assert type(pk).__name__ == 'UUIDField', f'Expected UUIDField, got {type(pk).__name__}'
-    assert content.SQL_TYPE == 'TEXT', f'Expected TEXT, got {content.SQL_TYPE}'
     assert 'RUN_IN_TRANSACTION = False' in aerich.migrate.MIGRATE_TEMPLATE
 
     await Tortoise.close_connections()


### PR DESCRIPTION
## Summary

DSQL now supports `JSON` and `JSONB` column types natively, so the adapter-side workarounds that compensated for their absence are no longer needed.

- **Django**: drop `has_native_json_field = False` so Django's `JSONField` works without the override.
- **SQLAlchemy**: restore the upstream `_columns_query` body so `identity_options` reflection uses `json_build_object` instead of returning NULL. Verified `json_build_object`, `pg_sequence`, and `pg_get_serial_sequence` all work in DSQL today.
- **SQLAlchemy README**: drop the "datatype json not supported" Dialect Features bullet.
- **Tortoise**: drop the `JSONField not supported` section from `KNOWN_ISSUES.md`.
- **Tortoise**: drop the Aerich `content` JSON→TEXT patch. Stock aerich uses `fields.JSONField(encoder, decoder)`, which now creates a JSONB column on DSQL. Updated the test, the README, and `ADAPTER_BEHAVIOR.md` to match.

### Backward compatibility — Aerich migration table

Existing users have an `aerich` table whose `content` column is TEXT (created under the prior patch). After this change, `aerich init-db` against a fresh DSQL cluster creates `content` as JSONB. Existing TEXT-typed tables continue to work at runtime: Tortoise's `JSONField` reads/writes JSON-encoded text unchanged regardless of column type. Users who want to convert can do so manually; we don't ship an automatic migration.

## Test plan

- [x] Django unit tests (`test_features.py`) pass after dropping the `has_native_json_field` override and the corresponding assertions.
- [x] Tortoise unit tests pass (119 tests, including the simplified `test_aerich_compat.py`).
- [x] SQLAlchemy `_columns_query` compiles and emits `json_build_object` (verified via local smoke test).
- [ ] SQLAlchemy integration tests against a live DSQL cluster (please run via CI).
- [ ] Tortoise integration tests against a live DSQL cluster (please run via CI).
---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/awslabs/aurora-dsql-orms/blob/main/LICENSE).
