### PR TITLE
fix(ci): grant update-changelog caller the permissions it needs

### DIFF
--- a/.github/workflows/java-hibernate-release.yml
+++ b/.github/workflows/java-hibernate-release.yml
@@ -54,4 +54,7 @@ jobs:
     uses: ./.github/workflows/update-changelog.yml
     with:
       tag: ${{ github.ref_name }}
+    permissions:
+      contents: write
+      pull-requests: write
     secrets: inherit

--- a/.github/workflows/python-django-release.yml
+++ b/.github/workflows/python-django-release.yml
@@ -85,4 +85,7 @@ jobs:
     uses: ./.github/workflows/update-changelog.yml
     with:
       tag: ${{ github.ref_name }}
+    permissions:
+      contents: write
+      pull-requests: write
     secrets: inherit

--- a/.github/workflows/python-sqlalchemy-release.yml
+++ b/.github/workflows/python-sqlalchemy-release.yml
@@ -85,4 +85,7 @@ jobs:
     uses: ./.github/workflows/update-changelog.yml
     with:
       tag: ${{ github.ref_name }}
+    permissions:
+      contents: write
+      pull-requests: write
     secrets: inherit

--- a/.github/workflows/python-tortoise-release.yml
+++ b/.github/workflows/python-tortoise-release.yml
@@ -85,4 +85,7 @@ jobs:
     uses: ./.github/workflows/update-changelog.yml
     with:
       tag: ${{ github.ref_name }}
+    permissions:
+      contents: write
+      pull-requests: write
     secrets: inherit


### PR DESCRIPTION
## Problem

The `java/hibernate/v2.0.0` release tag triggered a workflow `startup_failure` (nothing published). GitHub reported:

> Invalid workflow file: `.github/workflows/java-hibernate-release.yml#L52` — The nested job 'update-changelog' is requesting 'contents: write, pull-requests: write', but is only allowed 'contents: none, pull-requests: none'.

## Root cause

The Feb 3 refactor (#118) extracted `update-changelog.yml` as a reusable `workflow_call` (which requests `contents: write` + `pull-requests: write`) and switched the release workflows to `uses:` it — but dropped the per-job `permissions` block from the callers. With top-level `permissions: {}`, the nested job is granted `none`, so GitHub rejects the run at startup.

This was latent until the first release after the refactor: `java/hibernate/v2.0.0`. The same bug affects the django, sqlalchemy, and tortoise release workflows; `node-prisma-release.yml` already had the correct block.

## Fix

Add `permissions: { contents: write, pull-requests: write }` to the `update-changelog` calling job in all four affected workflows, matching node-prisma's working pattern.

## Follow-up

Once merged, the `java/hibernate/v2.0.0` tag will be re-pushed to re-trigger the (currently un-run) Maven Central publish. Nothing has been published yet.