### PR TITLE
fix(ci): scope hibernate release wait-for-ci to this module's checks

### DIFF
--- a/.github/workflows/java-hibernate-release.yml
+++ b/.github/workflows/java-hibernate-release.yml
@@ -19,7 +19,10 @@ jobs:
       - uses: lewagon/wait-on-check-action@v1.8.0
         with:
           ref: ${{ github.sha }}
-          running-workflow-name: "Wait for CI to pass"
+          # Gate only on this module's CI checks. The repo is a monorepo, so the
+          # release commit also carries unrelated checks (other ORMs, Dependabot)
+          # that must not block — or fail — the Hibernate publish.
+          check-regexp: "^(Build Dialect|Build Sample|Test Dialect|Test Sample|(create|delete)-cluster).*"
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           wait-interval: 30
 


### PR DESCRIPTION
## Problem

After the workflow-permissions fix (#490), the `java/hibernate/v2.0.0` release run started cleanly but **stalled on `wait-for-ci`**. The job uses `running-workflow-name`, which makes `lewagon/wait-on-check-action` wait on **every other check on the release commit**. In this monorepo that SHA also carries unrelated checks — other ORMs' tests (Python/Node) and **Dependabot security jobs**. Two unrelated Dependabot checks failed, which (with the action's default `allowed-conclusions: success,skipped`) blocks the Hibernate `deploy` from ever running.

## Fix

Replace `running-workflow-name` with `check-regexp` matching only this module's checks:

```
^(Build Dialect|Build Sample|Test Dialect|Test Sample|(create|delete)-cluster).*
```

Verified against the actual checks on the release commit: matches all 10 Hibernate checks (build, live-cluster `Test Dialect (Integration)`, all `Test Sample` variants, cluster create/delete) and excludes the unrelated Dependabot/Python/Node checks.

## Follow-up

Once merged, the `java/hibernate/v2.0.0` tag will be re-pointed to the new main to re-trigger the publish. Nothing has been published to Maven Central yet.