### PR TITLE
Pin js-yaml to patched 3.15.0 via override

### DIFF
--- a/node/prisma/package-lock.json
+++ b/node/prisma/package-lock.json
@@ -6073,9 +6073,9 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "3.14.2",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.2.tgz",
-      "integrity": "sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==",
+      "version": "3.15.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.0.tgz",
+      "integrity": "sha512-ttBQIIQPDeLjpPOohtUdXuXUVoA2uIB6fEH9HyJ7234s5mBJ5wTx20njxplLZQgLaOfpmPQA7X2t5AX6tIPbog==",
       "dev": true,
       "license": "MIT",
       "peer": true,

--- a/node/prisma/package.json
+++ b/node/prisma/package.json
@@ -59,13 +59,15 @@
   "overrides": {
     "lodash": "^4.17.23",
     "hono": "^4.11.10",
-    "fast-xml-parser": "^5.4.1"
+    "fast-xml-parser": "^5.4.1",
+    "js-yaml": "^3.15.0"
   },
   "comments": {
     "overrides": {
       "lodash": "CVE-2025-13465 - Remove when prisma updates to lodash >=4.17.23",
       "hono": "CVE-2026-24472 - Remove when prisma updates to hono >=4.11.10",
-      "fast-xml-parser": "Stack overflow in XMLBuilder - Remove when @aws-sdk/xml-builder updates to fast-xml-parser >=5.3.8"
+      "fast-xml-parser": "Stack overflow in XMLBuilder - Remove when @aws-sdk/xml-builder updates to fast-xml-parser >=5.3.8",
+      "js-yaml": "Quadratic-complexity DoS in merge key handling - Remove when ts-jest's @istanbuljs/load-nyc-config updates js-yaml >=3.15.0"
     }
   }
 }


### PR DESCRIPTION
## What

Adds a `js-yaml` override to `node/prisma/package.json` pinning it to the patched `^3.15.0`.

## Why

`js-yaml` was resolving to `3.14.2` as a transitive dev dependency:

```
ts-jest -> @istanbuljs/load-nyc-config -> js-yaml@^3.13.1
```

It was flagged for a medium-severity quadratic-complexity DoS in merge-key handling. Dependabot could not auto-fix it because the only update path it found would downgrade `ts-jest` 29.4.6 -> 27.0.3, so the Dependabot check stayed in `failure`. That failed check blocks the repo-wide release gate (`wait-on-check-action` requires all checks to be `success`/`skipped`).

## Fix

`3.15.0` is the lowest non-vulnerable version and is semver-compatible with the `^3.13.1` consumer, so an override forces the patched version without touching `ts-jest`. This mirrors the existing `lodash` / `hono` / `fast-xml-parser` override pattern already in this package.

## Verification

- `npm ls js-yaml` -> `js-yaml@3.15.0`
- `npm ls ts-jest` -> `ts-jest@29.4.6` (unchanged, no downgrade)
- `npm audit` -> js-yaml no longer flagged
- Only `node/prisma/package.json` + `package-lock.json` changed