### PR TITLE
feat(orms): support CHECK constraints (NOT VALID + VALIDATE ASYNC) in Django, SQLAlchemy, Hibernate

### DIFF
--- a/java/hibernate/dialect/src/main/java/software/amazon/dsql/hibernate/dialect/AuroraDSQLDialect.java
+++ b/java/hibernate/dialect/src/main/java/software/amazon/dsql/hibernate/dialect/AuroraDSQLDialect.java
@@ -311,7 +311,8 @@ public class AuroraDSQLDialect extends Dialect {
 
   @Override
   public boolean supportsColumnCheck() {
-    return false;
+    // DSQL supports inline column CHECK constraints at CREATE TABLE.
+    return true;
   }
 
   // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/java/hibernate/dialect/src/main/java/software/amazon/dsql/hibernate/dialect/AuroraDSQLDialect.java
+++ b/java/hibernate/dialect/src/main/java/software/amazon/dsql/hibernate/dialect/AuroraDSQLDialect.java
@@ -311,7 +311,6 @@ public class AuroraDSQLDialect extends Dialect {
 
   @Override
   public boolean supportsColumnCheck() {
-    // DSQL supports inline column CHECK constraints at CREATE TABLE.
     return true;
   }
 

--- a/java/hibernate/dialect/src/test/java/software/amazon/dsql/hibernate/dialect/AuroraDSQLDialectTest.java
+++ b/java/hibernate/dialect/src/test/java/software/amazon/dsql/hibernate/dialect/AuroraDSQLDialectTest.java
@@ -87,7 +87,7 @@ public class AuroraDSQLDialectTest {
 
   @Test
   public void testColumnCheck() {
-    assertFalse(dialect.supportsColumnCheck());
+    assertTrue(dialect.supportsColumnCheck());
   }
 
   @Test

--- a/python/django/aurora_dsql_django/features.py
+++ b/python/django/aurora_dsql_django/features.py
@@ -22,7 +22,10 @@ class DatabaseFeatures(features.DatabaseFeatures):
 
     supports_foreign_keys = False
 
-    supports_table_check_constraints = False
+    # Aurora DSQL supports CHECK constraints inline at CREATE TABLE, and can
+    # add them to existing tables via ADD CONSTRAINT ... NOT VALID followed by
+    # ALTER TABLE ASYNC ... VALIDATE CONSTRAINT (handled in the schema editor).
+    supports_table_check_constraints = True
 
     # Can it create foreign key constraints inline when adding columns?
     can_create_inline_fk = False

--- a/python/django/aurora_dsql_django/schema.py
+++ b/python/django/aurora_dsql_django/schema.py
@@ -32,6 +32,15 @@ class DatabaseSchemaEditor(schema.DatabaseSchemaEditor):
     # Remove constraint management from default updates.
     sql_update_with_default = "UPDATE %(table)s SET %(column)s = %(default)s WHERE %(column)s IS NULL"
 
+    # DSQL requires CHECK constraints added to an existing table to use
+    # NOT VALID; the rows are validated afterwards by a separate
+    # ALTER TABLE ASYNC ... VALIDATE CONSTRAINT statement (see add_constraint).
+    sql_create_check = "ALTER TABLE %(table)s ADD CONSTRAINT %(name)s CHECK (%(check)s) NOT VALID"
+
+    # Validate a NOT VALID constraint asynchronously. DSQL runs this as an
+    # async DDL job and returns immediately; progress can be tracked via sys.jobs.
+    sql_validate_check = "ALTER TABLE ASYNC %(table)s VALIDATE CONSTRAINT %(name)s"
+
     def __enter__(self):
         super().__enter__()
         # As long as DatabaseFeatures.can_rollback_ddl = False, compose() may
@@ -52,24 +61,20 @@ class DatabaseSchemaEditor(schema.DatabaseSchemaEditor):
             return
         super().remove_index(model, index, concurrently)
 
-    def _check_sql(self, name, check):
-        # There is no feature check in the upstream implementation when creating
-        # a model, so we add our own check.
-        if not self.connection.features.supports_table_check_constraints:
-            return None
-        return super()._check_sql(name, check)
-
     def add_constraint(self, model, constraint):
-        # Older versions of Django don't reference supports_table_check_constraints, so we add this as a backup.
-        if isinstance(constraint, CheckConstraint) and not self.connection.features.supports_table_check_constraints:
-            return
+        # DSQL adds a CHECK constraint to an existing table with NOT VALID
+        # (see sql_create_check), then validates existing rows asynchronously.
+        # Emit the VALIDATE CONSTRAINT ASYNC statement as a follow-up so the
+        # constraint is enforced against the data already in the table.
         super().add_constraint(model, constraint)
-
-    def remove_constraint(self, model, constraint):
-        # Older versions of Django don't reference supports_table_check_constraints, so we add this as a backup.
-        if isinstance(constraint, CheckConstraint) and not self.connection.features.supports_table_check_constraints:
-            return
-        super().remove_constraint(model, constraint)
+        if isinstance(constraint, CheckConstraint):
+            self.execute(
+                self.sql_validate_check
+                % {
+                    "table": self.quote_name(model._meta.db_table),
+                    "name": self.quote_name(constraint.name),
+                }
+            )
 
     def _index_columns(self, table, columns, col_suffixes, opclasses):
         # Aurora DSQL doesn't support PostgreSQL opclasses.

--- a/python/django/aurora_dsql_django/tests/unit/test_features.py
+++ b/python/django/aurora_dsql_django/tests/unit/test_features.py
@@ -22,7 +22,7 @@ class TestDatabaseFeatures(unittest.TestCase):
         self.assertFalse(self.features.supports_foreign_keys)
 
     def test_supports_check_constraints(self):
-        self.assertFalse(self.features.supports_table_check_constraints)
+        self.assertTrue(self.features.supports_table_check_constraints)
 
     def test_can_create_inline_fk(self):
         self.assertFalse(self.features.can_create_inline_fk)

--- a/python/django/aurora_dsql_django/tests/unit/test_schema.py
+++ b/python/django/aurora_dsql_django/tests/unit/test_schema.py
@@ -91,86 +91,48 @@ class TestDatabaseSchemaEditor(unittest.TestCase):
 
         self.assertIsNone(result)
 
-    @patch("aurora_dsql_django.schema.schema.DatabaseSchemaEditor._check_sql")
-    def test_check_sql_feature_disabled(self, mock_super_check_sql):
-        self.connection.features.supports_table_check_constraints = False
-
-        result = self.schema_editor._check_sql("test_check", "age >= 0")
-
-        self.assertIsNone(result)
-        mock_super_check_sql.assert_not_called()
-
-    @patch("aurora_dsql_django.schema.schema.DatabaseSchemaEditor._check_sql")
-    def test_check_sql_feature_enabled(self, mock_super_check_sql):
-        self.connection.features.supports_table_check_constraints = True
-        mock_super_check_sql.return_value = "CHECK (age >= 0)"
-
-        result = self.schema_editor._check_sql("test_check", "age >= 0")
-
-        mock_super_check_sql.assert_called_once_with("test_check", "age >= 0")
-        self.assertEqual(result, "CHECK (age >= 0)")
+    def test_sql_create_check_uses_not_valid(self):
+        # DSQL requires CHECK constraints on existing tables to be added
+        # NOT VALID, then validated asynchronously.
+        self.assertEqual(
+            self.schema_editor.sql_create_check,
+            "ALTER TABLE %(table)s ADD CONSTRAINT %(name)s CHECK (%(check)s) NOT VALID",
+        )
+        self.assertEqual(
+            self.schema_editor.sql_validate_check,
+            "ALTER TABLE ASYNC %(table)s VALIDATE CONSTRAINT %(name)s",
+        )
 
     @patch("aurora_dsql_django.schema.schema.DatabaseSchemaEditor.add_constraint")
-    def test_add_constraint_check_disabled(self, mock_super_add_constraint):
+    def test_add_check_constraint_validates_async(self, mock_super_add_constraint):
+        # Adding a CHECK constraint must delegate to super() (which emits the
+        # NOT VALID ADD via sql_create_check) and then issue VALIDATE CONSTRAINT
+        # ASYNC as a follow-up.
         model = MagicMock()
+        model._meta.db_table = "my_table"
+        self.schema_editor.quote_name = lambda n: f'"{n}"'
+        self.schema_editor.execute = MagicMock()
         constraint = create_check_constraint(Q(age__gte=0), "age_check")
-        self.connection.features.supports_table_check_constraints = False
-
-        result = self.schema_editor.add_constraint(model, constraint)
-
-        self.assertIsNone(result)
-        mock_super_add_constraint.assert_not_called()
-
-    @patch("aurora_dsql_django.schema.schema.DatabaseSchemaEditor.add_constraint")
-    def test_add_constraint_check_enabled(self, mock_super_add_constraint):
-        model = MagicMock()
-        constraint = create_check_constraint(Q(age__gte=0), "age_check")
-        self.connection.features.supports_table_check_constraints = True
 
         self.schema_editor.add_constraint(model, constraint)
 
         mock_super_add_constraint.assert_called_once_with(model, constraint)
+        self.schema_editor.execute.assert_called_once_with(
+            'ALTER TABLE ASYNC "my_table" VALIDATE CONSTRAINT "age_check"'
+        )
 
     @patch("aurora_dsql_django.schema.schema.DatabaseSchemaEditor.add_constraint")
-    def test_add_constraint_non_check(self, mock_super_add_constraint):
+    def test_add_non_check_constraint_no_validate(self, mock_super_add_constraint):
+        # Non-CHECK constraints (e.g. UNIQUE) must not trigger a follow-up
+        # VALIDATE CONSTRAINT statement.
         model = MagicMock()
+        self.schema_editor.execute = MagicMock()
         constraint = UniqueConstraint(fields=["name"], name="unique_name")
-        self.connection.features.supports_table_check_constraints = False
 
         self.schema_editor.add_constraint(model, constraint)
 
         mock_super_add_constraint.assert_called_once_with(model, constraint)
-
-    @patch("aurora_dsql_django.schema.schema.DatabaseSchemaEditor.remove_constraint")
-    def test_remove_constraint_check_disabled(self, mock_super_remove_constraint):
-        model = MagicMock()
-        constraint = create_check_constraint(Q(age__gte=0), "age_check")
-        self.connection.features.supports_table_check_constraints = False
-
-        result = self.schema_editor.remove_constraint(model, constraint)
-
-        self.assertIsNone(result)
-        mock_super_remove_constraint.assert_not_called()
-
-    @patch("aurora_dsql_django.schema.schema.DatabaseSchemaEditor.remove_constraint")
-    def test_remove_constraint_check_enabled(self, mock_super_remove_constraint):
-        model = MagicMock()
-        constraint = create_check_constraint(Q(age__gte=0), "age_check")
-        self.connection.features.supports_table_check_constraints = True
-
-        self.schema_editor.remove_constraint(model, constraint)
-
-        mock_super_remove_constraint.assert_called_once_with(model, constraint)
-
-    @patch("aurora_dsql_django.schema.schema.DatabaseSchemaEditor.remove_constraint")
-    def test_remove_constraint_non_check(self, mock_super_remove_constraint):
-        model = MagicMock()
-        constraint = UniqueConstraint(fields=["name"], name="unique_name")
-        self.connection.features.supports_table_check_constraints = False
-
-        self.schema_editor.remove_constraint(model, constraint)
-
-        mock_super_remove_constraint.assert_called_once_with(model, constraint)
+        self.schema_editor.execute.assert_not_called()
 
 
 if __name__ == "__main__":

--- a/python/django/aurora_dsql_django/tests/unit/test_schema.py
+++ b/python/django/aurora_dsql_django/tests/unit/test_schema.py
@@ -117,9 +117,7 @@ class TestDatabaseSchemaEditor(unittest.TestCase):
         self.schema_editor.add_constraint(model, constraint)
 
         mock_super_add_constraint.assert_called_once_with(model, constraint)
-        self.schema_editor.execute.assert_called_once_with(
-            'ALTER TABLE ASYNC "my_table" VALIDATE CONSTRAINT "age_check"'
-        )
+        self.schema_editor.execute.assert_called_once_with('ALTER TABLE ASYNC "my_table" VALIDATE CONSTRAINT "age_check"')
 
     @patch("aurora_dsql_django.schema.schema.DatabaseSchemaEditor.add_constraint")
     def test_add_non_check_constraint_no_validate(self, mock_super_add_constraint):

--- a/python/django/reference/ADAPTER_BEHAVIOR.md
+++ b/python/django/reference/ADAPTER_BEHAVIOR.md
@@ -62,14 +62,14 @@ See the [Working with sequences and identity columns](https://docs.aws.amazon.co
 
 **DSQL feature:** [SQL compatibility](https://docs.aws.amazon.com/aurora-dsql/latest/userguide/working-with-postgresql-compatibility.html)
 
-## Check constraint changes after table creation are skipped during migrations
+## Check constraints on existing tables are validated asynchronously
 
-**Behavior:** The Aurora DSQL adapter for Django automatically skips check constraints that are added to or removed from existing tables during migrations.
+**Behavior:** The Aurora DSQL adapter for Django supports `CHECK` constraints both inline at `CREATE TABLE` and added to existing tables during migrations. Because DSQL requires `CHECK` constraints on an existing table to be added with `NOT VALID`, the adapter emits two statements when adding a constraint: `ALTER TABLE ... ADD CONSTRAINT ... CHECK (...) NOT VALID`, followed by `ALTER TABLE ASYNC ... VALIDATE CONSTRAINT ...`.
 
 **Impact:**
-- Check constraint modifications on existing tables are not applied at the database level, meaning constraints may remain unenforced or continue being enforced based on their previous state
-- Applications must rely on Django model validation and application logic for data integrity when check constraints are not defined at table creation
-- Existing migrations from other databases will continue to work without modification
+- The constraint is enforced on all new inserts and updates as soon as the migration completes.
+- Validation of rows that already exist in the table runs as an asynchronous DSQL DDL job (returns a `job_id`); the migration does not block until it finishes.
+- If existing rows violate the constraint, the validation job fails and the constraint remains in the `NOT VALID` state (still enforced for new writes, but not marked valid for existing data). Track the outcome via the `sys.jobs` system view and fix offending rows before re-running validation. Migrations that add a constraint to a table with known-clean data are unaffected.
 
 **DSQL feature:** [ALTER TABLE syntax](https://docs.aws.amazon.com/aurora-dsql/latest/userguide/working-with-postgresql-compatibility-supported-sql-subsets.html#alter-table-syntax-support)
 

--- a/python/sqlalchemy/README.md
+++ b/python/sqlalchemy/README.md
@@ -146,6 +146,7 @@ See the [Working with sequences and identity columns](https://docs.aws.amazon.co
 ## Dialect Features
 
 - **Foreign Keys**: The dialect disables foreign key constraint generation. Referential integrity should be maintained at the application level.
+- **Check Constraints**: `CHECK` constraints are supported both inline at `CREATE TABLE` and when added to an existing table. Because DSQL requires a `CHECK` constraint added via `ALTER TABLE` to be marked `NOT VALID`, the dialect automatically appends `NOT VALID` to `ADD CONSTRAINT ... CHECK` statements. To validate the constraint against rows that already exist in the table, run `ALTER TABLE ASYNC <table> VALIDATE CONSTRAINT <name>` as a separate statement (for example, `op.execute(...)` in an Alembic migration). The constraint is enforced on all new writes immediately; validation of existing rows runs as an asynchronous DSQL DDL job. See [ALTER TABLE](https://docs.aws.amazon.com/aurora-dsql/latest/userguide/working-with-postgresql-compatibility-supported-sql-subsets.html#alter-table-syntax-support) for details.
 - **Index Creation**: The dialect uses `CREATE INDEX ASYNC` and `CREATE UNIQUE INDEX ASYNC` commands. See the [Asynchronous indexes in Aurora DSQL](https://docs.aws.amazon.com/aurora-dsql/latest/userguide/working-with-create-index-async.html) page for more information.
 
   The following parameters are used for customizing index creation

--- a/python/sqlalchemy/aurora_dsql_sqlalchemy/base.py
+++ b/python/sqlalchemy/aurora_dsql_sqlalchemy/base.py
@@ -7,7 +7,7 @@ from sqlalchemy import BIGINT, Integer, bindparam, select, sql
 from sqlalchemy.dialects.postgresql import pg_catalog
 from sqlalchemy.dialects.postgresql.base import PGDDLCompiler, PGDialect, PGTypeCompiler
 from sqlalchemy.dialects.postgresql.types import OID, REGCLASS
-from sqlalchemy.schema import ForeignKeyConstraint, PrimaryKeyConstraint
+from sqlalchemy.schema import CheckConstraint, ForeignKeyConstraint, PrimaryKeyConstraint
 from sqlalchemy.sql import expression, sqltypes
 from sqlalchemy.types import TEXT
 
@@ -205,6 +205,20 @@ class AuroraDSQLDDLCompiler(PGDDLCompiler):
         elif nulls_not_distinct is False:
             text += " NULLS DISTINCT"
 
+        return text
+
+    def visit_add_constraint(self, create, **kw):
+        """
+        DSQL requires CHECK constraints added to an existing table via
+        ALTER TABLE to be marked NOT VALID; a plain ADD CONSTRAINT ... CHECK
+        is rejected. Existing rows are validated separately and asynchronously
+        with `ALTER TABLE ASYNC <table> VALIDATE CONSTRAINT <name>` (run it as a
+        follow-up statement, e.g. op.execute(...) in an Alembic migration).
+        Non-CHECK constraints fall back to the standard behavior.
+        """
+        text = super().visit_add_constraint(create, **kw)
+        if isinstance(create.element, CheckConstraint):
+            text += " NOT VALID"
         return text
 
 

--- a/python/sqlalchemy/aurora_dsql_sqlalchemy/base.py
+++ b/python/sqlalchemy/aurora_dsql_sqlalchemy/base.py
@@ -7,7 +7,11 @@ from sqlalchemy import BIGINT, Integer, bindparam, select, sql
 from sqlalchemy.dialects.postgresql import pg_catalog
 from sqlalchemy.dialects.postgresql.base import PGDDLCompiler, PGDialect, PGTypeCompiler
 from sqlalchemy.dialects.postgresql.types import OID, REGCLASS
-from sqlalchemy.schema import CheckConstraint, ForeignKeyConstraint, PrimaryKeyConstraint
+from sqlalchemy.schema import (
+    CheckConstraint,
+    ForeignKeyConstraint,
+    PrimaryKeyConstraint,
+)
 from sqlalchemy.sql import expression, sqltypes
 from sqlalchemy.types import TEXT
 

--- a/python/sqlalchemy/test/test_compiler.py
+++ b/python/sqlalchemy/test/test_compiler.py
@@ -2,12 +2,14 @@
 # SPDX-License-Identifier: Apache-2.0
 
 from sqlalchemy import (
+    CheckConstraint,
     Column,
     Index,
     Integer,
     MetaData,
     String,
     Table,
+    UniqueConstraint,
     schema,
 )
 from sqlalchemy.testing import fixtures
@@ -115,3 +117,27 @@ class CompileTest(fixtures.TestBase, AssertsCompiledSQL):
             "CREATE INDEX ASYNC foo ON test (x) INCLUDE (y)",
             dialect=self.__dialect__,
         )
+
+    def test_add_check_constraint_is_not_valid(self):
+        # DSQL rejects a plain ALTER TABLE ADD CONSTRAINT ... CHECK; it must be
+        # added NOT VALID, then validated asynchronously as a separate step.
+        metadata = MetaData()
+        tbl = Table("test_tbl", metadata, Column("qty", Integer))
+        ck = CheckConstraint("qty >= 0", name="ck_qty", table=tbl)
+        self.assert_compile(
+            schema.AddConstraint(ck),
+            "ALTER TABLE test_tbl ADD CONSTRAINT ck_qty CHECK (qty >= 0) NOT VALID",
+            dialect=self.__dialect__,
+        )
+
+    def test_add_non_check_constraint_gets_no_not_valid(self):
+        # Guard: the NOT VALID suffix is CHECK-specific. DSQL does not support
+        # adding UNIQUE constraints via ALTER TABLE at all (they are created as
+        # CREATE UNIQUE INDEX ASYNC), so this only asserts our visit_add_constraint
+        # override leaves non-CHECK constraints untouched — it must not append
+        # NOT VALID to them.
+        metadata = MetaData()
+        tbl = Table("test_tbl", metadata, Column("data", String))
+        uq = UniqueConstraint(tbl.c.data, name="uq_data")
+        compiled = str(schema.AddConstraint(uq).compile(dialect=self.__dialect__))
+        assert "NOT VALID" not in compiled


### PR DESCRIPTION
## Summary

DSQL now supports adding `CHECK` constraints to existing tables via `ALTER TABLE ... ADD CONSTRAINT ... NOT VALID` followed by an asynchronous `ALTER TABLE ASYNC ... VALIDATE CONSTRAINT`, and supports inline `CHECK` constraints at `CREATE TABLE`. This PR enables real `CHECK` constraint support across the Django, SQLAlchemy, and Hibernate adapters, which previously skipped or disabled it.

## Changes

### Django (`python/django`)
- `features.py`: `supports_table_check_constraints = True`.
- `schema.py`: `sql_create_check` emits `ADD CONSTRAINT ... CHECK (...) NOT VALID`; `add_constraint` issues `ALTER TABLE ASYNC ... VALIDATE CONSTRAINT` as a follow-up so existing rows are validated. Removed the old skip logic (inline CREATE TABLE checks and `DROP CONSTRAINT` are supported).
- `reference/ADAPTER_BEHAVIOR.md`: replaced the "check constraints skipped" section with async-validation behavior and the `NOT VALID` caveat.

### SQLAlchemy (`python/sqlalchemy`)
- `base.py`: override `visit_add_constraint` to append `NOT VALID` for `CheckConstraint` (non-CHECK unaffected). `supports_alter` stays `False` (it also gates FK/PK-via-ALTER auto-ordering, still unsupported). The async `VALIDATE CONSTRAINT` step is run separately (e.g. `op.execute(...)` in Alembic), documented in the README.
- Inline `CHECK` at `CREATE TABLE` already worked and is unchanged.

### Hibernate (`java/hibernate`)
- `AuroraDSQLDialect.java`: `supportsColumnCheck()` returns `true` (inline column CHECK at CREATE TABLE).

## Behavior caveat

`VALIDATE CONSTRAINT ASYNC` returns immediately; validation of existing rows runs as an async DDL job. The constraint is enforced on new writes right away. If existing rows violate it, the async job fails and the constraint stays `NOT VALID` (track via `sys.jobs`).

## Testing

- Unit tests pass: Django (`pytest` schema + features), SQLAlchemy compiler assertions, Hibernate (`gradlew test`).
- **Verified end-to-end against a gamma DSQL cluster** for all three: inline CREATE TABLE checks; post-creation `ADD CONSTRAINT ... NOT VALID` + `VALIDATE CONSTRAINT ASYNC` (job `submitted` → `completed`, constraint enforced); async failure on dirty data (`sys.jobs` status `failed`, constraint stays `NOT VALID`); and confirmed a plain `ADD CONSTRAINT ... CHECK` without `NOT VALID` is rejected by DSQL.

---

**Part of the `VALIDATE CONSTRAINT ASYNC` rollout across the DSQL ecosystem:**
- dsql-lint: https://github.com/awslabs/aurora-dsql-tools/pull/112
- agent-plugins (canonical steering): https://github.com/awslabs/agent-plugins/pull/238
- mcp (mirror steering): https://github.com/awslabs/mcp/pull/4300
- aurora-dsql-orms (this PR)

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/awslabs/aurora-dsql-orms/blob/main/LICENSE).