### PR TITLE
Fix flaky specialty assertion in SQLAlchemy pet-clinic example

### DIFF
--- a/python/sqlalchemy/examples/pet-clinic-app/src/example.py
+++ b/python/sqlalchemy/examples/pet-clinic-app/src/example.py
@@ -192,13 +192,13 @@ def demo_pet_clinic_operations(engine):
     carlos_salazar = session.scalars(vet_query).one()
     print("Successfully fetched vet data: Carlos Salazar")
 
-    # Test: check read value
+    # Test: check read value. The many-to-many specialties collection has no
+    # defined order, so compare as sets rather than by index.
     assert akua_mansa.name == "Akua Mansa"
-    assert akua_mansa.specialties[0].id == "Dogs"
+    assert {s.id for s in akua_mansa.specialties} == {"Dogs"}
 
     assert carlos_salazar.name == "Carlos Salazar"
-    assert carlos_salazar.specialties[0].id == "Cats"
-    assert carlos_salazar.specialties[1].id == "Dogs"
+    assert {s.id for s in carlos_salazar.specialties} == {"Cats", "Dogs"}
 
     print("Finished demo pet clinic operations")
 


### PR DESCRIPTION
The many-to-many `Vet.specialties` relationship has no defined order, so
indexing into it (`specialties[0]`/`[1]`) depends on the row order the
database returns. The example asserted a specific order, which fails
intermittently — e.g. `examples/pet-clinic-app/src/example.py:200`
(`assert carlos_salazar.specialties[0].id == "Cats"`) when the collection
comes back Dogs-first.

Compare the specialty ids as sets instead, so the assertions hold
regardless of return order.

Verified against a live DSQL cluster: the current assertion fails, and the
set-based version passes on both `psycopg` and `psycopg2`.

---

*Issue #, if available:*
N/A

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
