### PR TITLE
fix(ci): scope drizzle release gate to its own checks

### DIFF
--- a/.github/workflows/node-drizzle-ci.yml
+++ b/.github/workflows/node-drizzle-ci.yml
@@ -52,6 +52,10 @@ jobs:
       id-token: write # required by aws-actions/configure-aws-credentials
 
   test-example:
+    # Named so the check is distinguishable from the identically-named job in
+    # node-prisma-ci.yml — both run on every main commit, and the release gate
+    # selects checks by name.
+    name: Example Integration Tests (Drizzle)
     needs: create-cluster
     runs-on: ubuntu-latest
     permissions:

--- a/.github/workflows/node-drizzle-release.yml
+++ b/.github/workflows/node-drizzle-release.yml
@@ -19,7 +19,13 @@ jobs:
       - uses: lewagon/wait-on-check-action@v1.9.1
         with:
           ref: ${{ github.sha }}
-          running-workflow-name: "Wait for CI to pass"
+          # Gate only on this package's own CI checks. The repo is a monorepo, so
+          # the release commit also carries unrelated checks (other ORMs,
+          # Dependabot, other releases' changelog jobs) that must not block — or
+          # fail — this publish. Both names are unique to node-drizzle-ci.yml;
+          # the example job needs cluster creation, which needs the build
+          # matrix, so the pair covers the chain.
+          check-regexp: "^(Build & unit test \\(Node \\d+\\)|Example Integration Tests \\(Drizzle\\))$"
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           wait-interval: 30
 


### PR DESCRIPTION
The drizzle release gate waited on every check on the tagged commit, so
unrelated monorepo checks — other ORMs, Dependabot, other releases'
changelog jobs — could block or fail the publish. The drizzle merge
commit (a8907f9) carries five failed Dependabot checks, which would have
sunk the first release.

Scope the gate to this package's own checks, matching the Python and
Hibernate release workflows (cd98089). The example job needs cluster
creation, which needs the build matrix, so the pair covers the chain.

Also name that job: its id matches the one in `node-prisma-ci.yml`, so
both emitted a bare `test-example` check on every main commit and a
name-based gate could not tell them apart. Verified against all 103
check runs on a8907f9 — the new pattern matches drizzle's checks only,
with no collisions across any `*-ci.yml` workflow.

`actionlint` and `prettier` clean. This PR touches `node-drizzle-ci.yml`,
so ci-gate runs the full drizzle CI (live cluster) and exercises the
renamed check before merge.

Note: the first `node/drizzle/v*` tag must be on a commit containing
this change, since that is the first commit whose checks carry the new
name. If an older commit is tagged, the gate matches nothing and fails
closed rather than publishing unverified (`fail-on-no-checks` defaults
to true).

*Issue #, if available:*
N/A

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
