### PR TITLE
fix(ci): allow a token for a package's first npm publish

### DIFF
--- a/.github/workflows/node-drizzle-release.yml
+++ b/.github/workflows/node-drizzle-release.yml
@@ -61,12 +61,14 @@ jobs:
         run: npm run build
 
       - name: Publish to npm
-        # Unset NODE_AUTH_TOKEN: actions/setup-node sets a placeholder token
-        # whenever `registry-url` is configured, and npm prefers that token
-        # over OIDC trusted publishing. Clearing it forces the OIDC path.
+        # actions/setup-node writes a placeholder token whenever `registry-url`
+        # is configured, and npm prefers a token over OIDC trusted publishing —
+        # so this stays empty to force the OIDC path. Trusted publishing cannot
+        # create a package name that does not exist on the registry yet, so set
+        # NPM_BOOTSTRAP_TOKEN for a package's first publish, then delete it.
         run: npm publish
         env:
-          NODE_AUTH_TOKEN: ""
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_BOOTSTRAP_TOKEN }}
 
   update-changelog:
     needs: publish-to-npm


### PR DESCRIPTION
Trusted publishing cannot create a package name that does not exist on the
registry yet. The first `@aws/aurora-dsql-drizzle@0.1.0` attempt built the
tarball correctly, then failed with `ENEEDAUTH`: the publish step clears
`NODE_AUTH_TOKEN` to force the OIDC path, and a trusted publisher cannot be
configured for a package that is not yet on the registry.

Read `NODE_AUTH_TOKEN` from an `NPM_BOOTSTRAP_TOKEN` secret so a package's
first publish can use a token. Provenance is unaffected — a token publish from
Actions still attests.

The secret is absent by default, so the value is empty and the OIDC path is
unchanged. Deleting it once the trusted publisher is registered restores the
default with no follow-up PR.

Note: the existing `node/drizzle/v0.1.0` tag points at a commit whose tree
still has the OIDC-only step, so the tag needs to be recreated on top of this
change — re-running the failed job would execute the old definition.

*Issue #, if available:*
N/A

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
