### PR TITLE
test(tortoise): enable aerich downgrade coverage for native DROP COLUMN

### DIFF
--- a/python/tortoise-orm/tests/integration/test_aerich.py
+++ b/python/tortoise-orm/tests/integration/test_aerich.py
@@ -161,7 +161,7 @@ async def test_aerich_add_column_migration(migration_dir, backend):
     assert "description" not in columns
 
     # Switch to V2 model and apply migration.
-    await migrate_to([ADD_COLUMN_V2], migration_dir, backend, "add_description")
+    command = await migrate_to([ADD_COLUMN_V2], migration_dir, backend, "add_description")
 
     # Verify new column exists.
     conn = Tortoise.get_connection("default")
@@ -179,8 +179,13 @@ async def test_aerich_add_column_migration(migration_dir, backend):
     )
     assert result[1][0]["description"] == "test desc"
 
-    # Note: Downgrade not tested here because DSQL doesn't support ALTER TABLE DROP COLUMN.
-    # See other tests for downgrade testing.
+    # Downgrade and verify the column is removed.
+    await command.downgrade(version=-1, delete=False)
+
+    conn = Tortoise.get_connection("default")
+    columns = await get_table_columns(conn, "incremental_test_model")
+    assert "description" not in columns, "description should be dropped after downgrade"
+    assert "name" in columns, "name should still exist"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

`test_aerich_add_column_migration` skipped its downgrade half behind this comment:

```python
# Note: Downgrade not tested here because DSQL doesn't support ALTER TABLE DROP COLUMN.
# See other tests for downgrade testing.
```

Aurora DSQL has supported `ALTER TABLE ... DROP COLUMN` since [2026-08-03](https://docs.aws.amazon.com/aurora-dsql/latest/userguide/release-notes.html), so the note is stale — and it was suppressing real coverage: the aerich downgrade path for a column-adding migration was going untested.

## Changes

- Capture the `Command` returned by `migrate_to()` so `downgrade()` can be called on it. The original code discarded the return value, so there was no handle to downgrade with.
- Downgrade and assert the added column is gone while its sibling survives.

This follows the shape already used by `test_aerich_add_model_and_downgrade_last` and `test_aerich_multi_model_migration` — same `command = await migrate_to(...)` capture, same `downgrade(version=-1, delete=False)` call, same connection re-fetch and assertion style. Column-level assertions use the existing `get_table_columns()` helper (as this test already does) rather than the `table_exists` the model-level siblings use, since this migration adds a column rather than a table. No new helper, fixture, or marker.

## Why the emitted SQL is safe on DSQL

aerich's `Migrate._remove_field` calls `ddl.drop_column`, and `PostgresDDL` inherits the base template `ALTER TABLE "{table_name}" DROP COLUMN "{column_name}"` — no `CASCADE`, no MySQL-style quoting. `aurora_dsql_tortoise/aerich/patch.py` does not intercept drops, so it reaches DSQL as a single-statement DDL, which is what DSQL requires. The column here is an ordinary non-key column, so it avoids the one restriction that remains: dropping a primary key column is still unsupported.

## Testing

This is an integration test requiring a live DSQL cluster and IAM auth (`tests/integration/conftest.py` validates `CLUSTER_ENDPOINT` at import time), so it runs in CI via the `dsql-cluster-create` workflow rather than locally. Verified offline:

- `pytest --collect-only tests/integration/test_aerich.py` → **26 tests collected**, including `test_aerich_add_column_migration[psycopg]` and `[asyncpg]`. Collection exercises the real import chain, including the DSQL backend registration.
- `ruff check` → all checks passed; `ruff format --check` → already formatted.

Please run the integration suite on this branch to confirm the downgrade passes against a real cluster.

## Related

Part of the DSQL `DROP COLUMN` rollout:

- Agent steering (canonical): [awslabs/agent-plugins#264](https://github.com/awslabs/agent-plugins/pull/264)
- Agent steering (mirror): [awslabs/mcp#4556](https://github.com/awslabs/mcp/pull/4556)

The adapters themselves already emit native `DROP COLUMN` as of #588 — this was the last spot in the repo still gated on the old limitation.
