### PR TITLE
Update Hibernate and Tortoise SELECT FOR UPDATE support

### DIFF
--- a/java/hibernate/README.md
+++ b/java/hibernate/README.md
@@ -97,8 +97,9 @@ Users should not use Hibernate's `OPTIMISTIC` lock mode, as DSQL handles OCC
 natively. The only two lock modes that should be used are:
 
 - `NONE` — standard DSQL OCC
-- `PESSIMISTIC_WRITE` — adds `SELECT ... FOR UPDATE`, which provides additional
-  read checks on selected rows
+- `PESSIMISTIC_WRITE` — adds `SELECT ... FOR UPDATE`, which adds optimistic
+  commit-time conflict checks for rows targeted by the locking clause. Each targeted
+  row's primary key counts toward the 10 MiB transaction-size limit
 
 ## Dialect Features
 

--- a/java/hibernate/dialect/src/main/java/software/amazon/dsql/hibernate/dialect/AuroraDSQLDialect.java
+++ b/java/hibernate/dialect/src/main/java/software/amazon/dsql/hibernate/dialect/AuroraDSQLDialect.java
@@ -129,7 +129,9 @@ import org.hibernate.type.spi.TypeConfiguration;
  *   <li>Multi-table mutations use CTE-based strategies, working within DSQL without temporary
  *       tables.
  *   <li>{@code TRUNCATE} is replaced with {@code DELETE}.
- *   <li>Locking is OCC-only; {@code SELECT ... FOR UPDATE} is supported for additional read checks.
+ *   <li>Locking is OCC-only; {@code SELECT ... FOR UPDATE} adds commit-time conflict checks for
+ *       rows targeted by the locking clause. Each targeted row's primary key counts toward the 10 MiB
+ *       transaction-size limit.
  *   <li>Sequences and identity columns require a mandatory {@code CACHE} parameter.
  * </ul>
  *

--- a/java/hibernate/dialect/src/test/java/software/amazon/dsql/hibernate/dialect/AuroraDSQLDialectTest.java
+++ b/java/hibernate/dialect/src/test/java/software/amazon/dsql/hibernate/dialect/AuroraDSQLDialectTest.java
@@ -65,7 +65,7 @@ public class AuroraDSQLDialectTest {
     assertFalse(dialect.supportsOuterJoinForUpdate());
     assertFalse(dialect.supportsWait());
 
-    // DSQL uses OCC; FOR UPDATE is supported for read-checks
+    // DSQL uses OCC; FOR UPDATE adds commit-time conflict checks
     assertEquals(" for update", dialect.getForUpdateString());
     assertEquals(" for update", dialect.getForUpdateString(null, new LockOptions()));
     assertEquals(" for update", dialect.getWriteLockString(0));

--- a/java/hibernate/dialect/src/test/java/software/amazon/dsql/hibernate/dialect/integration/LockingTest.java
+++ b/java/hibernate/dialect/src/test/java/software/amazon/dsql/hibernate/dialect/integration/LockingTest.java
@@ -17,6 +17,8 @@ import org.hibernate.query.Query;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
+import software.amazon.dsql.hibernate.dialect.integration.model.M2OEntityA;
+import software.amazon.dsql.hibernate.dialect.integration.model.M2OEntityB;
 import software.amazon.dsql.hibernate.dialect.integration.model.SimpleEntity;
 import software.amazon.dsql.hibernate.dialect.integration.model.VersionedEntity;
 
@@ -127,6 +129,36 @@ public class LockingTest extends DSQLHibernateBaseTest {
     }
   }
 
+  @Test
+  void testPessimisticLockWithJoinedNonKeyQuery() {
+    try (Session session = getSession()) {
+      session.beginTransaction();
+      M2OEntityB parent = new M2OEntityB();
+      parent.setValue("Lock Parent");
+      M2OEntityA child = new M2OEntityA();
+      child.setValue("Lock Child");
+      child.setEntityB(parent);
+      session.persist(parent);
+      session.persist(child);
+      session.getTransaction().commit();
+    }
+
+    try (Session session = getSession()) {
+      session.beginTransaction();
+      Query<M2OEntityA> query =
+          session
+              .createQuery(
+                  "SELECT a FROM M2OEntityA a JOIN FETCH a.m2OEntityB b WHERE b.value = :value",
+                  M2OEntityA.class)
+              .setParameter("value", "Lock Parent")
+              .setLockMode(PESSIMISTIC_WRITE);
+      M2OEntityA entity = query.getSingleResult();
+      Assertions.assertEquals("Lock Child", entity.getValue());
+      Assertions.assertEquals("Lock Parent", entity.getEntityB().getValue());
+      session.getTransaction().commit();
+    }
+  }
+
   /**
    * This test verifies that FOR UPDATE works with Hibernate's pessimistic locking. In this
    * scenario, a first transaction reads a value in entity 1 with SELECT FOR UPDATE, then attempts
@@ -210,6 +242,6 @@ public class LockingTest extends DSQLHibernateBaseTest {
 
   @Override
   protected List<Class<?>> getAnnotatedClasses() {
-    return List.of(SimpleEntity.class, VersionedEntity.class);
+    return List.of(SimpleEntity.class, VersionedEntity.class, M2OEntityA.class, M2OEntityB.class);
   }
 }

--- a/python/tortoise-orm/README.md
+++ b/python/tortoise-orm/README.md
@@ -118,6 +118,21 @@ The compatibility module patches Aerich to:
 Databases created by earlier adapter versions need a one-time explicit foreign
 key backfill migration. See [Adapter Behavior](docs/ADAPTER_BEHAVIOR.md#upgrading-an-existing-database).
 
+### SELECT FOR UPDATE
+
+Use `select_for_update()` inside `in_transaction()` and bind the queryset to that connection.
+Non-key predicates are supported. Tortoise relation filters and `select_related()` emit
+`LEFT OUTER JOIN`; do not combine them with untargeted `select_for_update()`. Use explicit SQL
+with an `INNER JOIN` for joined locking queries. Aurora DSQL does not take blocking row locks;
+rows targeted by the locking clause participate in commit-time optimistic conflict checks. Each
+targeted row's primary key counts toward the 10 MiB transaction-size limit. Retry the whole
+transaction with backoff when a conflict returns SQLSTATE `40001`, and keep external side effects
+outside the retried callback or make them idempotent.
+
+Tortoise `no_key=True` falls back to regular `FOR UPDATE` because Aurora DSQL does not support
+`FOR NO KEY UPDATE`. `update_or_create()` is supported because its existing-row path uses
+`SELECT FOR UPDATE`; both create and update paths can encounter commit-time conflicts.
+
 ## Features and Limitations
 
 - **[Adapter Behavior](docs/ADAPTER_BEHAVIOR.md)** - How the adapter modifies Tortoise ORM behavior for Aurora DSQL compatibility

--- a/python/tortoise-orm/aurora_dsql_tortoise/asyncpg/client.py
+++ b/python/tortoise-orm/aurora_dsql_tortoise/asyncpg/client.py
@@ -6,6 +6,7 @@ import aurora_dsql_asyncpg as dsql
 from tortoise.backends.asyncpg.client import AsyncpgDBClient
 
 from aurora_dsql_tortoise.asyncpg.schema_generator import AuroraDSQLAsyncpgSchemaGenerator
+from aurora_dsql_tortoise.common.capabilities import dsql_capabilities
 from aurora_dsql_tortoise.common.config import DSQL_CONNECTOR_PARAMS
 
 
@@ -14,6 +15,7 @@ class AuroraDSQLAsyncpgClient(AsyncpgDBClient):
 
     schema_generator = AuroraDSQLAsyncpgSchemaGenerator
     parameter_placeholder = "$1"
+    capabilities = dsql_capabilities(AsyncpgDBClient.capabilities)
 
     def __init__(self, *, database: str | None = "postgres", **kwargs):
         # Database is set for internal Tortoise usage. Connection defaults are

--- a/python/tortoise-orm/aurora_dsql_tortoise/common/capabilities.py
+++ b/python/tortoise-orm/aurora_dsql_tortoise/common/capabilities.py
@@ -1,0 +1,14 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from tortoise.backends.base.client import Capabilities
+
+
+def dsql_capabilities(postgres_capabilities: Capabilities) -> Capabilities:
+    """Copy PostgreSQL capabilities while disabling unsupported lock clauses."""
+    values = vars(postgres_capabilities).copy()
+    values.pop("_mutable", None)
+    dialect = values.pop("dialect")
+    values["support_for_update"] = True
+    values["support_for_no_key_update"] = False
+    return Capabilities(dialect, **values)

--- a/python/tortoise-orm/aurora_dsql_tortoise/psycopg/client.py
+++ b/python/tortoise-orm/aurora_dsql_tortoise/psycopg/client.py
@@ -11,6 +11,7 @@ from tortoise.backends.psycopg.client import (
     PsycopgClient,
 )
 
+from aurora_dsql_tortoise.common.capabilities import dsql_capabilities
 from aurora_dsql_tortoise.common.config import DSQL_CONNECTOR_PARAMS
 from aurora_dsql_tortoise.psycopg.schema_generator import AuroraDSQLPsycopgSchemaGenerator
 
@@ -20,6 +21,7 @@ class AuroraDSQLPsycopgClient(PsycopgClient):
 
     schema_generator = AuroraDSQLPsycopgSchemaGenerator
     parameter_placeholder = "%s"
+    capabilities = dsql_capabilities(PsycopgClient.capabilities)
 
     def __init__(self, *, database: str | None = "postgres", **kwargs):
         # Database is set for internal Tortoise usage. Connection defaults are

--- a/python/tortoise-orm/docs/KNOWN_ISSUES.md
+++ b/python/tortoise-orm/docs/KNOWN_ISSUES.md
@@ -10,40 +10,6 @@ This document tracks known issues when using the Aurora DSQL adapter for Tortois
 
 **Workaround:** Restructure code to avoid nested transactions.
 
-## SELECT FOR UPDATE
-
-**Issue:** Calling `select_for_update()` on a queryset fails.
-
-```python
-# This will fail
-await MyModel.filter(id=some_id).select_for_update().first()
-```
-
-**Workaround:** Aurora DSQL uses optimistic concurrency control (OCC). Remove `select_for_update()` calls and handle potential `SerializationFailure` errors with retry logic.
-
-## update_or_create
-
-**Issue:** Calling `update_or_create()` fails.
-
-**Why:** The Tortoise ORM `update_or_create()` implementation uses `SELECT FOR UPDATE` internally.
-
-**Workaround:** Use `bulk_create` with `on_conflict` for atomic upserts:
-
-```python
-class Item(Model):
-    name = fields.CharField(max_length=100, unique=True)  # unique constraint required
-    value = fields.CharField(max_length=100)
-
-# Atomic upsert using ON CONFLICT
-await Item.bulk_create(
-    [Item(name="test", value="new_value")],
-    on_conflict=["name"],
-    update_fields=["value"],
-)
-```
-
-Note: `bulk_create` does not return `(instance, created)`. Fetch the row afterward if needed.
-
 ## Aerich compatibility module prevents side-by-side PostgreSQL use
 
 **Issue:** Enabling the Aerich compatibility module (`aurora_dsql_tortoise.aerich_compat`) prevents using standard PostgreSQL and Aurora DSQL in the same application.

--- a/python/tortoise-orm/tests/integration/test_query_execution.py
+++ b/python/tortoise-orm/tests/integration/test_query_execution.py
@@ -9,6 +9,7 @@ from tortoise.expressions import Q
 from tortoise.fields.relational import ReverseRelation
 from tortoise.functions import Avg, Count, Max, Min, Sum
 from tortoise.models import Model
+from tortoise.transactions import in_transaction
 
 from tests.conftest import BACKENDS
 
@@ -59,6 +60,62 @@ class TestJoins:
         books = await Book.filter(author__name="Carol").all()
         assert len(books) == 1
         assert books[0].title == "C1"
+
+
+@pytest.mark.asyncio
+@pytest.mark.use_schemas
+@pytest.mark.parametrize("backend", BACKENDS, indirect=True)
+class TestSelectForUpdate:
+    async def test_non_key_filter(self, backend):
+        author = await Author.create(name="Lock Author")
+        await Book.create(title="Lock Book", price=42, author=author)
+
+        async with in_transaction() as connection:
+            book = await Book.filter(price=42).using_db(connection).select_for_update().first()
+
+            assert book is not None
+            assert book.title == "Lock Book"
+
+    async def test_no_key_falls_back_to_for_update(self, backend):
+        sql = Book.all().select_for_update(no_key=True).sql()
+
+        assert "FOR UPDATE" in sql
+        assert "FOR NO KEY UPDATE" not in sql
+
+    async def test_update_or_create_creates(self, backend):
+        author = await Author.create(name="Create Author")
+
+        book, created = await Book.update_or_create(
+            title="Created Book",
+            author=author,
+            defaults={"price": 10},
+        )
+
+        assert created is True
+        assert book.price == 10
+
+    async def test_update_or_create_updates(self, backend, monkeypatch):
+        select_for_update_called = False
+        original_select_for_update = Book.select_for_update
+
+        def tracked_select_for_update(cls, *args, **kwargs):
+            nonlocal select_for_update_called
+            select_for_update_called = True
+            return original_select_for_update(*args, **kwargs)
+
+        monkeypatch.setattr(Book, "select_for_update", classmethod(tracked_select_for_update))
+        author = await Author.create(name="Update Author")
+        await Book.create(title="Updated Book", price=10, author=author)
+
+        book, created = await Book.update_or_create(
+            title="Updated Book",
+            author=author,
+            defaults={"price": 20},
+        )
+
+        assert created is False
+        assert book.price == 20
+        assert select_for_update_called is True
 
 
 @pytest.mark.asyncio

--- a/python/tortoise-orm/tests/unit/test_asyncpg_client.py
+++ b/python/tortoise-orm/tests/unit/test_asyncpg_client.py
@@ -4,6 +4,7 @@
 from unittest.mock import MagicMock, patch
 
 import pytest
+from tortoise.backends.asyncpg.client import AsyncpgDBClient
 
 from aurora_dsql_tortoise.asyncpg.client import AuroraDSQLAsyncpgClient
 from tests.unit.conftest import TEST_HOST, TEST_USER
@@ -97,3 +98,9 @@ async def test_pool_param_passed_to_create_pool(param, value, mock_create_pool, 
     await client.create_pool(**pool_kwargs(**{param: value}))
 
     assert param in captured_kwargs["kwargs"], f"{param} should be passed to dsql.create_pool"
+
+
+def test_select_for_update_capabilities():
+    expected = vars(AsyncpgDBClient.capabilities) | {"support_for_no_key_update": False}
+
+    assert vars(AuroraDSQLAsyncpgClient.capabilities) == expected

--- a/python/tortoise-orm/tests/unit/test_psycopg_client.py
+++ b/python/tortoise-orm/tests/unit/test_psycopg_client.py
@@ -7,6 +7,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import aurora_dsql_psycopg as dsql
 import psycopg
 import pytest
+from tortoise.backends.psycopg.client import PsycopgClient
 
 from aurora_dsql_tortoise.psycopg.client import AuroraDSQLPsycopgClient
 from tests.unit.conftest import TEST_HOST, TEST_USER
@@ -188,3 +189,9 @@ async def test_default_connection_class(mock_pool, captured_kwargs):
     await client.create_pool(**pool_kwargs())
 
     assert captured_kwargs["connection_class"] is dsql.DSQLAsyncConnection
+
+
+def test_select_for_update_capabilities():
+    expected = vars(PsycopgClient.capabilities) | {"support_for_no_key_update": False}
+
+    assert vars(AuroraDSQLPsycopgClient.capabilities) == expected


### PR DESCRIPTION
## Summary

Update Aurora DSQL ORM adapters and guidance for the GA SELECT FOR UPDATE behavior. Part of a coordinated rollout; sibling PR links will be added after all PRs are opened.

## Changes

- Update Hibernate guidance and add coverage for non-key predicates with an inner join.
- Preserve Hibernate's outer-join limitation.
- Enable Tortoise `select_for_update()` while disabling unsupported `FOR NO KEY UPDATE`.
- Add Tortoise coverage for non-key filters and both `update_or_create()` paths.
- Document commit-time OCC behavior, SQLSTATE 40001 retries, and 10 MiB locked-primary-key accounting.
- Document Tortoise's outer-join query-builder limitation for joined locking queries.

## Validation

- Hibernate: `./gradlew test` passed.
- Tortoise: Ruff format/lint passed; 124 unit tests and 6 subtests passed.
- Live Aurora DSQL integration tests were not run locally.

## Related rollout PRs

- Canonical agent guidance: awslabs/agent-plugins#271
- Kiro Power mirror: awslabs/mcp#4607
- Flyway compatibility cleanup: flyway/flyway-community-db-support#149
- ORM adapters: awslabs/aurora-dsql-orms#626
- Samples: aws-samples/aurora-dsql-samples#1821